### PR TITLE
data 1.0.0-rc.1: license, README, version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19402,7 +19402,7 @@
     },
     "packages/jp-local-gov-id-data": {
       "name": "@b4moss/jp-local-gov-id-data",
-      "version": "0.1.0",
+      "version": "1.0.0-rc.1",
       "license": "MIT"
     },
     "scripts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19393,7 +19393,7 @@
       "version": "0.4.2",
       "license": "MIT",
       "devDependencies": {
-        "@b4moss/jp-local-gov-id-data": "0.1.0",
+        "@b4moss/jp-local-gov-id-data": "1.0.0-rc.1",
         "typescript": "^5.8.3",
         "vite": "^6.3.5",
         "vite-plugin-dts": "^4.5.4",

--- a/packages/jp-local-gov-id-data/README.md
+++ b/packages/jp-local-gov-id-data/README.md
@@ -2,7 +2,9 @@
 
 [日本語](./README_ja.md)
 
-Split JSON datasets of Japan’s nationwide local government codes. Use with [`@b4moss/jp-local-gov-id`](../jp-local-gov-id), or host the files yourself behind a versioned index URL.
+Split JSON datasets of Japan’s nationwide local government codes (全国地方公共団体コード).
+
+This package ships **data only**. For search and lookup APIs, use [`@b4moss/jp-local-gov-id`](https://www.npmjs.com/package/@b4moss/jp-local-gov-id) with this package, or serve the same files yourself behind a versioned index URL.
 
 ## Install
 
@@ -10,7 +12,20 @@ Split JSON datasets of Japan’s nationwide local government codes. Use with [`@
 npm install @b4moss/jp-local-gov-id-data
 ```
 
-## Usage with the API package
+## What’s included
+
+| Path | Contents |
+|------|----------|
+| `index.json` | Index metadata (`schemaVersion`, `asOf`, paths, counts, …) |
+| `prefectures.json` | All prefectures |
+| `prefectures/{code}.json` | Municipalities for that prefecture (e.g. `13.json`) |
+| `dataset.js` | Default export bundling the above for the API package |
+
+A single JSON file of all municipalities is **not** distributed.
+
+## Import
+
+Default dataset (for the API package):
 
 ```ts
 import { createLocalGovClient } from "@b4moss/jp-local-gov-id";
@@ -19,22 +34,13 @@ import dataset from "@b4moss/jp-local-gov-id-data";
 const client = await createLocalGovClient({ data: dataset });
 ```
 
-You can also import individual files:
+Individual JSON files:
 
 ```ts
 import index from "@b4moss/jp-local-gov-id-data/index.json";
 import prefectures from "@b4moss/jp-local-gov-id-data/prefectures.json";
+import tokyo from "@b4moss/jp-local-gov-id-data/prefectures/13.json";
 ```
-
-## Data layout
-
-A single JSON file of all municipalities is **not** distributed.
-
-| File | Contents |
-|------|----------|
-| `index.json` | Index of paths, `schemaVersion`, `asOf`, etc. |
-| `prefectures.json` | Prefectures only |
-| `prefectures/{code}.json` | Municipalities for that prefecture (e.g. `13.json`) |
 
 ### Dataset exports
 
@@ -42,21 +48,21 @@ A single JSON file of all municipalities is **not** distributed.
 |--------|-------------|
 | `index` | Index metadata |
 | `prefectures` | All prefectures |
-| `municipalitiesByCode` | Prefetched municipality files keyed by prefecture code |
+| `municipalitiesByCode` | Municipality files keyed by prefecture code |
 | `loadMunicipalities(code)` | Load municipalities for a prefecture code |
 
-## Hosting your own data
+## Self-hosted data
 
-If you host the JSON yourself, serve it with a **versioned URL** and the same split-file layout. The package maintainers take no responsibility for availability, CORS, correctness, or URL management. Enable CORS on the hosting side.
+If you host the JSON yourself, serve it with a **versioned URL** and the same split-file layout. Availability, CORS, correctness, and URL operations are your responsibility. Enable CORS on the hosting side.
 
 ## About the data
 
 - As of: 1 January 2024 (R6.1.1)
-- Source file: `resources/000925835.xlsx`
+- Source: Ministry of Internal Affairs and Communications (総務省) nationwide local government code Excel (`000925835.xlsx` in the monorepo `resources/`)
 - Abolished / merged entities are not included (current only)
 
 ## License
 
 MIT
 
-See the [monorepo README](../../README.md) for API usage, versioning, and development notes.
+Repository: [b4moss/jp-local-gov-id](https://github.com/b4moss/jp-local-gov-id)

--- a/packages/jp-local-gov-id-data/README_ja.md
+++ b/packages/jp-local-gov-id-data/README_ja.md
@@ -2,7 +2,9 @@
 
 [English](./README.md)
 
-日本の全国地方公共団体コードの分割 JSON データです。[`@b4moss/jp-local-gov-id`](../jp-local-gov-id) と組み合わせて使うか、版付きインデックス URL で自前配信できます。
+日本の全国地方公共団体コードの分割 JSON データです。
+
+このパッケージは**データのみ**を提供します。検索・取得 API が必要な場合は [`@b4moss/jp-local-gov-id`](https://www.npmjs.com/package/@b4moss/jp-local-gov-id) と組み合わせて使うか、同等のファイルを版付きインデックス URL で自前配信してください。
 
 ## インストール
 
@@ -10,7 +12,20 @@
 npm install @b4moss/jp-local-gov-id-data
 ```
 
-## API パッケージとの併用
+## 同梱内容
+
+| パス | 内容 |
+|------|------|
+| `index.json` | 索引メタデータ（`schemaVersion`・`asOf`・パス・件数など） |
+| `prefectures.json` | 都道府県のみ |
+| `prefectures/{code}.json` | 当該県の市区町村（例: `13.json`） |
+| `dataset.js` | API パッケージ向けのデフォルト export |
+
+全市区町村をまとめた単一 JSON は**配布しません**。
+
+## インポート
+
+API パッケージ向けのデフォルトデータセット:
 
 ```ts
 import { createLocalGovClient } from "@b4moss/jp-local-gov-id";
@@ -19,22 +34,13 @@ import dataset from "@b4moss/jp-local-gov-id-data";
 const client = await createLocalGovClient({ data: dataset });
 ```
 
-個別ファイルの import も可能です:
+個別 JSON:
 
 ```ts
 import index from "@b4moss/jp-local-gov-id-data/index.json";
 import prefectures from "@b4moss/jp-local-gov-id-data/prefectures.json";
+import tokyo from "@b4moss/jp-local-gov-id-data/prefectures/13.json";
 ```
-
-## データ構成
-
-全市区町村をまとめた単一 JSON は**配布しません**。
-
-| ファイル | 内容 |
-|----------|------|
-| `index.json` | パス・`schemaVersion`・`asOf` などの索引 |
-| `prefectures.json` | 都道府県のみ |
-| `prefectures/{code}.json` | 当該県の市区町村（例: `13.json`） |
 
 ### データセットの export
 
@@ -45,18 +51,18 @@ import prefectures from "@b4moss/jp-local-gov-id-data/prefectures.json";
 | `municipalitiesByCode` | 都道府県コードをキーにした市区町村ファイル |
 | `loadMunicipalities(code)` | 都道府県コードで市区町村を読み込む |
 
-## 自前データ配信について
+## 自前データ配信
 
-自前で JSON を配信する場合も、公式と同様に**バージョン付き URL**と同等の分割ファイル構成で提供してください。可用性・CORS・内容の正しさ・URL 運用などについて、当パッケージ開発者は一切の責任を負いません。CORS は配信側で許可してください。
+自前で JSON を配信する場合も、**バージョン付き URL**と同等の分割ファイル構成で提供してください。可用性・CORS・内容の正しさ・URL 運用は配信側の責任です。CORS は配信側で許可してください。
 
 ## データについて
 
 - 時点: 令和 6 年 1 月 1 日（R6.1.1）
-- ソースファイル: `resources/000925835.xlsx`
+- 出典: 総務省 全国地方公共団体コード Excel（モノレポ `resources/` 内の `000925835.xlsx`）
 - 廃止・合併済みの団体は含みません（現行のみ）
 
 ## ライセンス
 
 MIT
 
-API の使い方・バージョン方針・開発手順は [モノレポ README](../../README_ja.md) を参照してください。
+リポジトリ: [b4moss/jp-local-gov-id](https://github.com/b4moss/jp-local-gov-id)

--- a/packages/jp-local-gov-id-data/package.json
+++ b/packages/jp-local-gov-id-data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@b4moss/jp-local-gov-id-data",
-  "version": "0.1.0",
+  "version": "1.0.0-rc.1",
   "description": "日本の全国地方公共団体コードのデータ（分割 JSON）",
   "type": "module",
   "main": "./dataset.js",

--- a/packages/jp-local-gov-id/package.json
+++ b/packages/jp-local-gov-id/package.json
@@ -38,7 +38,7 @@
     "access": "public"
   },
   "devDependencies": {
-    "@b4moss/jp-local-gov-id-data": "0.1.0",
+    "@b4moss/jp-local-gov-id-data": "1.0.0-rc.1",
     "typescript": "^5.8.3",
     "vite": "^6.3.5",
     "vite-plugin-dts": "^4.5.4",


### PR DESCRIPTION
## Summary
- Closes #19 — data package LICENSE is already MIT (no file change)
- Closes #22 — rewrite `packages/jp-local-gov-id-data` README (EN/JA) for npm data-package consumers
- Closes #20 — bump `@b4moss/jp-local-gov-id-data` to `1.0.0-rc.1` (lockfile synced)
- Excel source hash is intentionally not added

## Branch strategy
Per git-rule: `dev-v1.0.0-rc.1` from `develop` → PR to `develop`.

## Follow-up (not in this PR)
- After merge to `main`, tag release as `data-1.0.0-rc.1` (note: current publish workflow matches `data-v*`)

## Test plan
- [ ] Review README EN/JA as published package docs
- [ ] Confirm `packages/jp-local-gov-id-data/package.json` version is `1.0.0-rc.1`
- [ ] CI green on this PR