### PR TITLE
Hotfix: fix repository.url for npm provenance

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -96,7 +96,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           set -euo pipefail
-          expected='https://github.com/b4m-oss/jp-local-gov-id'
+          expected='https://github.com/b4moss/jp-local-gov-id'
           pkg_dir='packages/jp-local-gov-id-data'
 
           node <<'EOF'
@@ -105,7 +105,7 @@ jobs:
           const pkg = JSON.parse(fs.readFileSync(path, 'utf8'));
           pkg.repository = {
             type: 'git',
-            url: 'https://github.com/b4m-oss/jp-local-gov-id',
+            url: 'https://github.com/b4moss/jp-local-gov-id',
             directory: 'packages/jp-local-gov-id-data',
           };
           fs.writeFileSync(path, JSON.stringify(pkg, null, 2) + '\n');
@@ -130,7 +130,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           set -euo pipefail
-          expected='https://github.com/b4m-oss/jp-local-gov-id'
+          expected='https://github.com/b4moss/jp-local-gov-id'
           pkg_dir='packages/jp-local-gov-id'
 
           node <<'EOF'
@@ -139,7 +139,7 @@ jobs:
           const pkg = JSON.parse(fs.readFileSync(path, 'utf8'));
           pkg.repository = {
             type: 'git',
-            url: 'https://github.com/b4m-oss/jp-local-gov-id',
+            url: 'https://github.com/b4moss/jp-local-gov-id',
             directory: 'packages/jp-local-gov-id',
           };
           fs.writeFileSync(path, JSON.stringify(pkg, null, 2) + '\n');

--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/b4m-oss/jp-local-gov-id"
+    "url": "https://github.com/b4moss/jp-local-gov-id"
   }
 }

--- a/packages/jp-local-gov-id-data/package.json
+++ b/packages/jp-local-gov-id-data/package.json
@@ -35,7 +35,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/b4m-oss/jp-local-gov-id",
+    "url": "https://github.com/b4moss/jp-local-gov-id",
     "directory": "packages/jp-local-gov-id-data"
   },
   "publishConfig": {

--- a/packages/jp-local-gov-id/package.json
+++ b/packages/jp-local-gov-id/package.json
@@ -31,7 +31,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/b4m-oss/jp-local-gov-id",
+    "url": "https://github.com/b4moss/jp-local-gov-id",
     "directory": "packages/jp-local-gov-id"
   },
   "publishConfig": {

--- a/scripts/check-publish.mjs
+++ b/scripts/check-publish.mjs
@@ -14,7 +14,7 @@ import { fileURLToPath } from "node:url";
 const root = join(fileURLToPath(new URL(".", import.meta.url)), "..");
 const require = createRequire(import.meta.url);
 
-const EXPECTED_REPO_URL = "https://github.com/b4m-oss/jp-local-gov-id";
+const EXPECTED_REPO_URL = "https://github.com/b4moss/jp-local-gov-id";
 
 const packages = [
   {

--- a/scripts/inject-repository.mjs
+++ b/scripts/inject-repository.mjs
@@ -6,7 +6,7 @@
 import { readFileSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 
-const EXPECTED_REPO_URL = "https://github.com/b4m-oss/jp-local-gov-id";
+const EXPECTED_REPO_URL = "https://github.com/b4moss/jp-local-gov-id";
 
 const targetDir = process.argv[2];
 if (!targetDir) {

--- a/scripts/publish-package.mjs
+++ b/scripts/publish-package.mjs
@@ -19,7 +19,7 @@ import {
 import { tmpdir } from "node:os";
 import { basename, join, resolve } from "node:path";
 
-const EXPECTED_REPO_URL = "https://github.com/b4m-oss/jp-local-gov-id";
+const EXPECTED_REPO_URL = "https://github.com/b4moss/jp-local-gov-id";
 
 const args = process.argv.slice(2);
 const dryRun = args.includes("--dry-run");


### PR DESCRIPTION
## Summary
- npm publish failed for `data-v1.0.0-rc.1` because provenance expects `https://github.com/b4moss/jp-local-gov-id` while package/workflow still used `b4m-oss`
- Update repository URLs in package manifests, publish workflow, and publish helper scripts

## Test plan
- [ ] Re-run Publish for `data-v1.0.0-rc.1` after merge
- [ ] Confirm `@b4moss/jp-local-gov-id-data@1.0.0-rc.1` on npm