### PR TITLE
Migrate npm publish to Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -81,6 +81,9 @@ jobs:
           node-version: 22
           registry-url: https://registry.npmjs.org
 
+      - name: Upgrade npm for Trusted Publishing
+        run: npm install -g npm@latest
+
       - name: Install dependencies
         run: npm ci
 
@@ -92,8 +95,6 @@ jobs:
 
       - name: Publish @b4moss/jp-local-gov-id-data
         if: ${{ steps.target.outputs.package == 'data' }}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           set -euo pipefail
           expected='https://github.com/b4moss/jp-local-gov-id'
@@ -126,8 +127,6 @@ jobs:
 
       - name: Publish @b4moss/jp-local-gov-id
         if: ${{ steps.target.outputs.package == 'api' }}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           set -euo pipefail
           expected='https://github.com/b4moss/jp-local-gov-id'


### PR DESCRIPTION
## Summary
- publish workflow から `NPM_TOKEN` / `NODE_AUTH_TOKEN` を除去
- Trusted Publishing 用に `npm@latest` を導入（既存の `id-token: write` + `--provenance` はそのまま）
- 参照実装: `b4moss/crudian` の OIDC publish

Closes #21

## Manual setup（マージ前/直後）
対象パッケージ両方で Trusted Publisher を設定:
- `@b4moss/jp-local-gov-id`
- `@b4moss/jp-local-gov-id-data`

GitHub repo: `b4moss/jp-local-gov-id` / Workflow filename: `publish.yml`（パスなし）

動作確認後、不要な `NPM_TOKEN` secret を削除。

## Test plan
- [ ] Workflow に `NODE_AUTH_TOKEN` / `NPM_TOKEN` が残っていないこと
- [ ] npm 側 Trusted Publisher を両パッケージに登録
- [ ] （任意）`workflow_dispatch` または Release 経由で OIDC publish を確認