### PR TITLE
docs: standardize README status badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # jp-local-gov-id
 
+[![CI](https://github.com/b4moss/jp-local-gov-id/actions/workflows/ci.yml/badge.svg)](https://github.com/b4moss/jp-local-gov-id/actions/workflows/ci.yml)
+[![Coverage](https://img.shields.io/codecov/c/github/b4moss/jp-local-gov-id)](https://codecov.io/gh/b4moss/jp-local-gov-id)
+[![npm](https://img.shields.io/npm/v/@b4moss/jp-local-gov-id)](https://www.npmjs.com/package/@b4moss/jp-local-gov-id)
+[![Release](https://img.shields.io/github/v/release/b4moss/jp-local-gov-id)](https://github.com/b4moss/jp-local-gov-id/releases)
+[![License](https://img.shields.io/github/license/b4moss/jp-local-gov-id)](https://github.com/b4moss/jp-local-gov-id/blob/main/LICENSE)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/b4moss/jp-local-gov-id/badge)](https://securityscorecards.dev/viewer/?uri=github.com/b4moss/jp-local-gov-id)
+
 [日本語](./README_ja.md)
 
 A monorepo for Japan’s nationwide local government codes (npm workspaces).

--- a/README_ja.md
+++ b/README_ja.md
@@ -1,5 +1,12 @@
 # jp-local-gov-id
 
+[![CI](https://github.com/b4moss/jp-local-gov-id/actions/workflows/ci.yml/badge.svg)](https://github.com/b4moss/jp-local-gov-id/actions/workflows/ci.yml)
+[![Coverage](https://img.shields.io/codecov/c/github/b4moss/jp-local-gov-id)](https://codecov.io/gh/b4moss/jp-local-gov-id)
+[![npm](https://img.shields.io/npm/v/@b4moss/jp-local-gov-id)](https://www.npmjs.com/package/@b4moss/jp-local-gov-id)
+[![Release](https://img.shields.io/github/v/release/b4moss/jp-local-gov-id)](https://github.com/b4moss/jp-local-gov-id/releases)
+[![License](https://img.shields.io/github/license/b4moss/jp-local-gov-id)](https://github.com/b4moss/jp-local-gov-id/blob/main/LICENSE)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/b4moss/jp-local-gov-id/badge)](https://securityscorecards.dev/viewer/?uri=github.com/b4moss/jp-local-gov-id)
+
 [English](./README.md)
 
 日本の全国地方公共団体コードを扱うモノレポです（npm workspaces）。


### PR DESCRIPTION
## Summary
- README 先頭のステータスバッジを標準セットに統一（既存バッジは置き換え）
- 言語/配布形態に応じてパッケージバッジを調整（Go / npm / PyPI / Homebrew / PHP / Shell）
- CI バッジはリポジトリの実ワークフロー名に合わせています

## Test plan
- [ ] 各 README でバッジが表示されること
- [ ] 既存の本文・言語スイッチャー・masthead 画像が残っていること
