### PR TITLE
app: getMunicipalityCountByPrefecture (#35)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ A monorepo for Japan’s nationwide local government codes (npm workspaces).
 
 | Package | Description | Version |
 |---------|-------------|---------|
-| [`@b4moss/jp-local-gov-id`](./packages/jp-local-gov-id) | JS API (data not bundled; lazy-loaded) | 0.6.0 |
-| [`@b4moss/jp-local-gov-id-data`](./packages/jp-local-gov-id-data) | Split JSON datasets | 1.0.0-rc.1 |
+| [`@b4moss/jp-local-gov-id`](./packages/jp-local-gov-id) | JS API (data not bundled; lazy-loaded) | 1.0.0-rc.1 |
+| [`@b4moss/jp-local-gov-id-data`](./packages/jp-local-gov-id-data) | Split JSON datasets | 1.0.0-rc.2 |
 
 ## Install (consumers)
 
@@ -35,6 +35,8 @@ const client = await createLocalGovClient({ data: dataset });
 
 client.listPrefectures();
 client.getPrefectureByCode("27"); // Osaka
+client.getMunicipalityCountByPrefecture("01"); // sync; no municipality JSON load
+client.getMunicipalityCountByPrefecture("北海道", { designatedCity: "city" });
 client.getPrefectureCodeByName("大阪府"); // "27"
 await client.listMunicipalitiesByPrefecture("13"); // municipalities in Tokyo, etc.
 await client.getMunicipalityByCode("131016"); // Chiyoda City

--- a/README_ja.md
+++ b/README_ja.md
@@ -8,8 +8,8 @@
 
 | パッケージ | 説明 | バージョン |
 |------------|------|------------|
-| [`@b4moss/jp-local-gov-id`](./packages/jp-local-gov-id) | JS API（データ非同梱・遅延ロード） | 0.6.0 |
-| [`@b4moss/jp-local-gov-id-data`](./packages/jp-local-gov-id-data) | 分割データ JSON | 1.0.0-rc.1 |
+| [`@b4moss/jp-local-gov-id`](./packages/jp-local-gov-id) | JS API（データ非同梱・遅延ロード） | 1.0.0-rc.1 |
+| [`@b4moss/jp-local-gov-id-data`](./packages/jp-local-gov-id-data) | 分割データ JSON | 1.0.0-rc.2 |
 
 ## インストール（利用側）
 
@@ -35,6 +35,8 @@ const client = await createLocalGovClient({ data: dataset });
 
 client.listPrefectures();
 client.getPrefectureByCode("27"); // 大阪府
+client.getMunicipalityCountByPrefecture("01"); // 同期・県別 JSON 不要
+client.getMunicipalityCountByPrefecture("北海道", { designatedCity: "city" });
 client.getPrefectureCodeByName("大阪府"); // "27"
 await client.listMunicipalitiesByPrefecture("13"); // 東京都の市区町村等
 await client.getMunicipalityByCode("131016"); // 千代田区

--- a/docs/logics.md
+++ b/docs/logics.md
@@ -25,6 +25,7 @@
 | `prefectureCode` | 所属都道府県コード（都道府県自身の場合は自身） |
 | `prefectureName` | 所属都道府県名 |
 | `prefectureNameKana` | 所属都道府県カナ |
+| `municipalityCounts?` | 都道府県のみ。`{ both, city, ward }`（`designatedCity` と同キー） |
 
 ### `SearchOptions`
 
@@ -49,7 +50,7 @@
 2. 政令市本体: 上記区から市名プレフィックス（例: `札幌市`）を集め、同名のレコード
 3. 町村・一般市・東京特別区（`千代田区` 等）は全モードで残す
 
-適用 API: `listMunicipalitiesByPrefecture` / `searchByText` / `getLocalGovCodeByName`
+適用 API: `listMunicipalitiesByPrefecture` / `searchByText` / `getLocalGovCodeByName` / `getMunicipalityCountByPrefecture`
 
 文字列比較前にクエリ・データ双方へ正規化を適用する:
 
@@ -103,6 +104,13 @@
 
 - 都道府県名の完全一致 → 2 桁コード
 - 見つからなければ `null`
+
+##### `getMunicipalityCountByPrefecture(pref, options?)` → `number | null`
+
+- `pref`: コードまたは名称（`listMunicipalitiesByPrefecture` と同じ解決）
+- `options.designatedCity`: `"both"` \| `"city"` \| `"ward"`（既定 `"both"`）
+- 初期化済み都道府県の `municipalityCounts[mode]` を返す（同期・県別 JSON 不要）
+- 未知の都道府県 / 件数未載荷 → `null`
 
 ##### `listMunicipalitiesByPrefecture(pref, options?)` → `Promise<LocalGov[]>`
 

--- a/docs/main.md
+++ b/docs/main.md
@@ -174,6 +174,12 @@ type LocalGov = {
   prefectureCode: string       // 例: "13"
   prefectureName: string       // 例: "東京都"
   prefectureNameKana: string   // 半角カナ（例: "ﾄｳｷｮｳﾄ"）
+  /** 都道府県レコードのみ。市区町村には付かない */
+  municipalityCounts?: {
+    both: number
+    city: number
+    ward: number
+  }
 }
 
 // 都道府県の場合、prefectureCode / prefectureName / prefectureNameKana は自身の値とする
@@ -218,6 +224,14 @@ type LocalGovClient = {
   listPrefectures(): LocalGov[]
   getPrefectureByCode(code: string): LocalGov | null
   getPrefectureCodeByName(name: string): string | null
+  /**
+   * 都道府県の municipalityCounts から件数を返す（同期・県別 JSON 不要）
+   * pref はコードまたは名称。未知は null。designatedCity 既定 "both"
+   */
+  getMunicipalityCountByPrefecture(
+    pref: string,
+    options?: ListMunicipalitiesOptions,
+  ): number | null
 
   /** 未ロードなら県別 JSON を取得してから返す */
   listMunicipalitiesByPrefecture(
@@ -243,6 +257,8 @@ const client = await createLocalGovClient({
 client.listPrefectures()
 client.getPrefectureCodeByName("大阪府")
 client.getPrefectureByCode("27")
+client.getMunicipalityCountByPrefecture("01")
+client.getMunicipalityCountByPrefecture("北海道", { designatedCity: "city" })
 
 await client.listMunicipalitiesByPrefecture("大阪府")
 await client.listMunicipalitiesByPrefecture("01", { designatedCity: "city" }) // 政令市本体のみ

--- a/package-lock.json
+++ b/package-lock.json
@@ -19390,7 +19390,7 @@
     },
     "packages/jp-local-gov-id": {
       "name": "@b4moss/jp-local-gov-id",
-      "version": "0.6.0",
+      "version": "1.0.0-rc.1",
       "license": "MIT",
       "devDependencies": {
         "@b4moss/jp-local-gov-id-data": "1.0.0-rc.2",

--- a/packages/jp-local-gov-id/README.md
+++ b/packages/jp-local-gov-id/README.md
@@ -27,6 +27,8 @@ const client = await createLocalGovClient({ data: dataset });
 client.listPrefectures();
 client.getPrefectureByCode("27");
 client.getPrefectureCodeByName("大阪府"); // "27"
+client.getMunicipalityCountByPrefecture("01"); // sync; no municipality JSON load
+client.getMunicipalityCountByPrefecture("北海道", { designatedCity: "city" });
 await client.listMunicipalitiesByPrefecture("13");
 await client.listMunicipalitiesByPrefecture("01", { designatedCity: "city" }); // city body only
 await client.getMunicipalityByCode("131016");
@@ -36,7 +38,7 @@ await client.searchByText("ちよだ", { prefecture: "13", target: "cities" });
 await client.getLocalGovCodeByName("千代田区"); // "131016"
 ```
 
-`designatedCity` (`"both"` | `"city"` | `"ward"`, default `"both"`) filters designated-city bodies vs wards on `listMunicipalitiesByPrefecture`, `searchByText`, and `getLocalGovCodeByName`. Tokyo special wards are not affected.
+`designatedCity` (`"both"` | `"city"` | `"ward"`, default `"both"`) filters designated-city bodies vs wards on `listMunicipalitiesByPrefecture`, `searchByText`, `getLocalGovCodeByName`, and `getMunicipalityCountByPrefecture`. Tokyo special wards are not affected.
 
 Fetch from a versioned index URL:
 

--- a/packages/jp-local-gov-id/README_ja.md
+++ b/packages/jp-local-gov-id/README_ja.md
@@ -27,6 +27,8 @@ const client = await createLocalGovClient({ data: dataset });
 client.listPrefectures();
 client.getPrefectureByCode("27");
 client.getPrefectureCodeByName("大阪府"); // "27"
+client.getMunicipalityCountByPrefecture("01"); // 同期・県別 JSON 不要
+client.getMunicipalityCountByPrefecture("北海道", { designatedCity: "city" });
 await client.listMunicipalitiesByPrefecture("13");
 await client.listMunicipalitiesByPrefecture("01", { designatedCity: "city" }); // 政令市本体のみ
 await client.getMunicipalityByCode("131016");
@@ -36,7 +38,7 @@ await client.searchByText("ちよだ", { prefecture: "13", target: "cities" });
 await client.getLocalGovCodeByName("千代田区"); // "131016"
 ```
 
-`designatedCity`（`"both"` | `"city"` | `"ward"`、既定 `"both"`）で、政令指定都市の市本体 / 行政区の出し分けができます。適用 API は `listMunicipalitiesByPrefecture` / `searchByText` / `getLocalGovCodeByName`。東京特別区は対象外です。
+`designatedCity`（`"both"` | `"city"` | `"ward"`、既定 `"both"`）で、政令指定都市の市本体 / 行政区の出し分けができます。適用 API は `listMunicipalitiesByPrefecture` / `searchByText` / `getLocalGovCodeByName` / `getMunicipalityCountByPrefecture`。東京特別区は対象外です。
 
 版付きインデックス URL から取得する場合:
 

--- a/packages/jp-local-gov-id/package.json
+++ b/packages/jp-local-gov-id/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@b4moss/jp-local-gov-id",
-  "version": "0.6.0",
+  "version": "1.0.0-rc.1",
   "description": "日本の全国地方公共団体コードを扱う npm パッケージ",
   "type": "module",
   "main": "./dist/jp-local-gov-id.js",

--- a/packages/jp-local-gov-id/src/api.test.ts
+++ b/packages/jp-local-gov-id/src/api.test.ts
@@ -113,6 +113,84 @@ describe("getPrefectureByCode", () => {
   });
 });
 
+describe("getMunicipalityCountByPrefecture", () => {
+  it("TC-A01: resolves code and name to the same both count", async () => {
+    const c = await client();
+    const byPadded = c.getMunicipalityCountByPrefecture("01");
+    const byUnpadded = c.getMunicipalityCountByPrefecture("1");
+    const byName = c.getMunicipalityCountByPrefecture("北海道");
+
+    expect(byPadded).toBe(195);
+    expect(byUnpadded).toBe(195);
+    expect(byName).toBe(195);
+  });
+
+  it("TC-A02: Hokkaido designatedCity modes", async () => {
+    const c = await client();
+    expect(c.getMunicipalityCountByPrefecture("01")).toBe(195);
+    expect(
+      c.getMunicipalityCountByPrefecture("01", { designatedCity: "both" }),
+    ).toBe(195);
+    expect(
+      c.getMunicipalityCountByPrefecture("01", { designatedCity: "city" }),
+    ).toBe(185);
+    expect(
+      c.getMunicipalityCountByPrefecture("01", { designatedCity: "ward" }),
+    ).toBe(194);
+  });
+
+  it("TC-A03/A05: Tokyo modes are equal (special wards included)", async () => {
+    const c = await client();
+    const both = c.getMunicipalityCountByPrefecture("13");
+    const city = c.getMunicipalityCountByPrefecture("東京都", {
+      designatedCity: "city",
+    });
+    const ward = c.getMunicipalityCountByPrefecture("13", {
+      designatedCity: "ward",
+    });
+
+    expect(both).toBe(62);
+    expect(city).toBe(62);
+    expect(ward).toBe(62);
+  });
+
+  it("TC-A04: Okinawa modes are equal", async () => {
+    const c = await client();
+    expect(c.getMunicipalityCountByPrefecture("47")).toBe(41);
+    expect(
+      c.getMunicipalityCountByPrefecture("沖縄県", { designatedCity: "city" }),
+    ).toBe(41);
+    expect(
+      c.getMunicipalityCountByPrefecture("47", { designatedCity: "ward" }),
+    ).toBe(41);
+  });
+
+  it("TC-A06: unknown prefecture returns null", async () => {
+    const c = await client();
+    expect(c.getMunicipalityCountByPrefecture("99")).toBeNull();
+    expect(c.getMunicipalityCountByPrefecture("存在しない県")).toBeNull();
+    expect(c.getMunicipalityCountByPrefecture("")).toBeNull();
+  });
+
+  it("TC-A07: municipalityCounts is on prefecture records", async () => {
+    const c = await client();
+    const expected = { both: 195, city: 185, ward: 194 };
+
+    expect(c.getPrefectureByCode("01")?.municipalityCounts).toEqual(expected);
+    expect(
+      c.listPrefectures().find((p) => p.code === "01")?.municipalityCounts,
+    ).toEqual(expected);
+  });
+
+  it("TC-A08: returns sync number without loading municipalities", async () => {
+    const c = await client();
+    const result = c.getMunicipalityCountByPrefecture("01");
+
+    expect(result).toBe(195);
+    expect(result).not.toBeInstanceOf(Promise);
+  });
+});
+
 describe("listMunicipalitiesByPrefecture", () => {
   it("accepts name, padded code, and unpadded code", async () => {
     const c = await client();

--- a/packages/jp-local-gov-id/src/api.ts
+++ b/packages/jp-local-gov-id/src/api.ts
@@ -96,6 +96,17 @@ export function buildLocalGovClient(store: LocalGovStore): LocalGovClient {
       return store.prefectureByName.get(name)?.code ?? null;
     },
 
+    getMunicipalityCountByPrefecture(
+      pref: string,
+      options?: ListMunicipalitiesOptions,
+    ): number | null {
+      const code = resolvePrefectureCode(store, pref);
+      if (!code) return null;
+      const counts = store.prefectureByCode.get(code)?.municipalityCounts;
+      if (!counts) return null;
+      return counts[options?.designatedCity ?? "both"];
+    },
+
     async listMunicipalitiesByPrefecture(
       pref: string,
       options?: ListMunicipalitiesOptions,

--- a/packages/jp-local-gov-id/src/index.ts
+++ b/packages/jp-local-gov-id/src/index.ts
@@ -11,6 +11,7 @@ export type {
   LocalGovMunicipalitiesFile,
   LocalGovPrefecturesFile,
   MatchField,
+  MunicipalityCounts,
   SearchOptions,
   SearchTarget,
 } from "./types";

--- a/packages/jp-local-gov-id/src/types.ts
+++ b/packages/jp-local-gov-id/src/types.ts
@@ -1,3 +1,9 @@
+export type MunicipalityCounts = {
+  both: number;
+  city: number;
+  ward: number;
+};
+
 export type LocalGov = {
   code: string;
   name: string;
@@ -5,6 +11,8 @@ export type LocalGov = {
   prefectureCode: string;
   prefectureName: string;
   prefectureNameKana: string;
+  /** Present on prefecture records only (from `prefectures.json`). */
+  municipalityCounts?: MunicipalityCounts;
 };
 
 export type SearchTarget = "all" | "prefectures" | "cities";
@@ -105,6 +113,15 @@ export type LocalGovClient = {
   listPrefectures(): LocalGov[];
   getPrefectureByCode(code: string): LocalGov | null;
   getPrefectureCodeByName(name: string): string | null;
+  /**
+   * Sync count from prefecture `municipalityCounts` (no municipality file load).
+   * `pref` accepts code or name. Unknown prefecture → `null`.
+   * Default designatedCity: `"both"`.
+   */
+  getMunicipalityCountByPrefecture(
+    pref: string,
+    options?: ListMunicipalitiesOptions,
+  ): number | null;
   listMunicipalitiesByPrefecture(
     pref: string,
     options?: ListMunicipalitiesOptions,

--- a/site/content/en/api.md
+++ b/site/content/en/api.md
@@ -28,6 +28,7 @@ Exactly one of `data` or `url` is required. `cache` / `cacheTtlSeconds` apply to
 | `prefectureCode` | `string` | Prefecture code (2 digits) |
 | `prefectureName` | `string` | Prefecture name |
 | `prefectureNameKana` | `string` | Prefecture kana |
+| `municipalityCounts?` | `{ both, city, ward }` | Prefecture records only; counts by `designatedCity` mode |
 
 ## Methods
 
@@ -36,6 +37,7 @@ Exactly one of `data` or `url` is required. `cache` / `cacheTtlSeconds` apply to
 | `listPrefectures()` | `LocalGov[]` | All prefectures |
 | `getPrefectureByCode(code)` | `LocalGov \| null` | Lookup by prefecture code |
 | `getPrefectureCodeByName(name)` | `string \| null` | Prefecture code from exact name |
+| `getMunicipalityCountByPrefecture(pref, options?)` | `number \| null` | Sync count from `municipalityCounts` (no municipality JSON load) |
 | `listMunicipalitiesByPrefecture(pref, options?)` | `Promise<LocalGov[]>` | Municipalities in a prefecture (lazy) |
 | `getMunicipalityByCode(code)` | `Promise<LocalGov \| null>` | Lookup by 6-digit municipality code |
 | `getByCode(code)` | `Promise<LocalGov \| null>` | Auto-detect 2-digit / 6-digit |
@@ -52,9 +54,9 @@ Filters designated-city bodies vs administrative wards. Default is `"both"`. Tok
 | `"city"` | City body only (exclude wards) |
 | `"ward"` | Wards only (exclude city bodies) |
 
-Applies to: `listMunicipalitiesByPrefecture` / `searchByText` / `getLocalGovCodeByName`
+Applies to: `listMunicipalitiesByPrefecture` / `searchByText` / `getLocalGovCodeByName` / `getMunicipalityCountByPrefecture`
 
-### `listMunicipalitiesByPrefecture` options
+### `listMunicipalitiesByPrefecture` / `getMunicipalityCountByPrefecture` options
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|

--- a/site/content/ja/api.md
+++ b/site/content/ja/api.md
@@ -28,6 +28,7 @@ description: LocalGovClient の公開メソッド
 | `prefectureCode` | `string` | 都道府県コード（2 桁） |
 | `prefectureName` | `string` | 都道府県名 |
 | `prefectureNameKana` | `string` | 都道府県カナ |
+| `municipalityCounts?` | `{ both, city, ward }` | 都道府県のみ。`designatedCity` モード別件数 |
 
 ## メソッド
 
@@ -36,6 +37,7 @@ description: LocalGovClient の公開メソッド
 | `listPrefectures()` | `LocalGov[]` | 全都道府県 |
 | `getPrefectureByCode(code)` | `LocalGov \| null` | 都道府県コードで取得 |
 | `getPrefectureCodeByName(name)` | `string \| null` | 正式名称から都道府県コード |
+| `getMunicipalityCountByPrefecture(pref, options?)` | `number \| null` | `municipalityCounts` から同期で件数取得（県別 JSON 不要） |
 | `listMunicipalitiesByPrefecture(pref, options?)` | `Promise<LocalGov[]>` | 県内の市区町村（遅延ロード） |
 | `getMunicipalityByCode(code)` | `Promise<LocalGov \| null>` | 市区町村 6 桁で取得 |
 | `getByCode(code)` | `Promise<LocalGov \| null>` | 2 桁 / 6 桁を自動判定 |
@@ -52,9 +54,9 @@ description: LocalGovClient の公開メソッド
 | `"city"` | 市本体のみ（行政区を除外） |
 | `"ward"` | 区のみ（市本体を除外） |
 
-適用 API: `listMunicipalitiesByPrefecture` / `searchByText` / `getLocalGovCodeByName`
+適用 API: `listMunicipalitiesByPrefecture` / `searchByText` / `getLocalGovCodeByName` / `getMunicipalityCountByPrefecture`
 
-### `listMunicipalitiesByPrefecture` の options
+### `listMunicipalitiesByPrefecture` / `getMunicipalityCountByPrefecture` の options
 
 | キー | 型 | 既定 | 説明 |
 |------|-----|------|------|


### PR DESCRIPTION
## Summary
- Closes #35 — add sync `getMunicipalityCountByPrefecture(pref, options?)` reading `municipalityCounts` from initialized prefecture data
- Type `LocalGov.municipalityCounts?` / `MunicipalityCounts`; bump `@b4moss/jp-local-gov-id` to `1.0.0-rc.1`
- Docs (main/logics/README EN·JA/site api) and contract tests for designatedCity modes

## Test plan
- [x] `npm test -w @b4moss/jp-local-gov-id` (61 tests green)
- [ ] Spot-check `"01"` / `"1"` / `"北海道"` → same both count
- [ ] Spot-check Tokyo/Okinawa three modes equal; unknown pref → `null`


Made with [Cursor](https://cursor.com)