### PR TITLE
hotfix: publish prereleases with --tag rc

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,7 @@ name: Publish
 # Tag push alone does not publish; create and publish a GitHub Release.
 # Manual workflow_dispatch is also available.
 # repository.url is injected before pack so older tags still work with provenance.
+# Prerelease versions (e.g. 1.0.0-rc.1) are published with --tag rc (npm requires a non-latest tag).
 on:
   release:
     types: [published]
@@ -123,7 +124,13 @@ jobs:
             echo "::error::Packed repository.url must be ${expected} (got '${url}')"
             exit 1
           fi
-          npm publish "$tgz" --access public --provenance
+          version=$(node -p "require('/tmp/packed-package.json').version")
+          publish_args=(--access public --provenance)
+          if [[ "$version" == *-* ]]; then
+            publish_args+=(--tag rc)
+            echo "prerelease detected (${version}); using --tag rc"
+          fi
+          npm publish "$tgz" "${publish_args[@]}"
 
       - name: Publish @b4moss/jp-local-gov-id
         if: ${{ steps.target.outputs.package == 'api' }}
@@ -155,4 +162,10 @@ jobs:
             echo "::error::Packed repository.url must be ${expected} (got '${url}')"
             exit 1
           fi
-          npm publish "$tgz" --access public --provenance
+          version=$(node -p "require('/tmp/packed-package.json').version")
+          publish_args=(--access public --provenance)
+          if [[ "$version" == *-* ]]; then
+            publish_args+=(--tag rc)
+            echo "prerelease detected (${version}); using --tag rc"
+          fi
+          npm publish "$tgz" "${publish_args[@]}"

--- a/scripts/publish-package.mjs
+++ b/scripts/publish-package.mjs
@@ -93,15 +93,18 @@ try {
     process.exit(0);
   }
 
-  execFileSync(
-    "npm",
-    ["publish", tgzPath, "--access", "public", "--provenance"],
-    {
-      cwd: staging,
-      stdio: "inherit",
-      env: process.env,
-    },
-  );
+  const version = String(packedPkg.version ?? "");
+  const publishArgs = ["publish", tgzPath, "--access", "public", "--provenance"];
+  if (version.includes("-")) {
+    publishArgs.push("--tag", "rc");
+    console.log(`prerelease detected (${version}); using --tag rc`);
+  }
+
+  execFileSync("npm", publishArgs, {
+    cwd: staging,
+    stdio: "inherit",
+    env: process.env,
+  });
 } finally {
   rmSync(staging, { recursive: true, force: true });
 }


### PR DESCRIPTION
## Summary
- Fix npm publish failure: `You must specify a tag using --tag when publishing a prerelease version`
- Prerelease versions (e.g. `1.0.0-rc.*`) now publish with `--tag rc`; stable versions stay on `latest`
- Same logic in `.github/workflows/publish.yml` and `scripts/publish-package.mjs`

## Test plan
- [ ] Merge to `main`
- [ ] Re-run Publish via `workflow_dispatch` for `data` and `api`
- [ ] Confirm npm dist-tags include `rc` for `1.0.0-rc.2` / `1.0.0-rc.1`


Made with [Cursor](https://cursor.com)