### PR TITLE
hotfix: unset NODE_AUTH_TOKEN for Trusted Publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -130,6 +130,10 @@ jobs:
             publish_args+=(--tag rc)
             echo "prerelease detected (${version}); using --tag rc"
           fi
+          # Prefer Trusted Publishing (OIDC). A stale/bypass-2FA token in
+          # NODE_AUTH_TOKEN causes PUT 404 and blocks provenance-based publish.
+          unset NODE_AUTH_TOKEN
+          npm config delete "//registry.npmjs.org/:_authToken" >/dev/null 2>&1 || true
           npm publish "$tgz" "${publish_args[@]}"
 
       - name: Publish @b4moss/jp-local-gov-id
@@ -168,4 +172,6 @@ jobs:
             publish_args+=(--tag rc)
             echo "prerelease detected (${version}); using --tag rc"
           fi
+          unset NODE_AUTH_TOKEN
+          npm config delete "//registry.npmjs.org/:_authToken" >/dev/null 2>&1 || true
           npm publish "$tgz" "${publish_args[@]}"


### PR DESCRIPTION
## Summary
- After `--tag rc`, publish still failed with `E404` on PUT
- npm warns that tokens bypassing 2FA are restricted for direct publishing
- Unset `NODE_AUTH_TOKEN` / authToken before `npm publish` so OIDC Trusted Publishing is used

## Test plan
- [ ] Merge to main
- [ ] Re-run Publish (`data` / `api`) via workflow_dispatch
- [ ] Confirm packages appear under dist-tag `rc`


Made with [Cursor](https://cursor.com)