### PR TITLE
hotfix: drop registry-url so OIDC publishes without token

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -80,7 +80,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 22
-          registry-url: https://registry.npmjs.org
+          # Do not set registry-url here: it injects NODE_AUTH_TOKEN into .npmrc.
+          # Trusted Publishing (OIDC + id-token: write) must authenticate npm publish.
 
       - name: Upgrade npm for Trusted Publishing
         run: npm install -g npm@latest


### PR DESCRIPTION
## Summary
- `--tag rc` works, but publish still returns `E404` (permission)
- `actions/setup-node` `registry-url` injects `NODE_AUTH_TOKEN` / `always-auth` into `.npmrc`, which conflicts with Trusted Publishing after npm's bypass-2FA token restrictions
- Remove `registry-url` so publish relies on OIDC (`id-token: write`)

## Test plan
- [ ] Merge, retag `app-v1.0.0-rc.1` / `data-v1.0.0-rc.2` onto new main tip, recreate releases
- [ ] Confirm Publish succeeds and `npm view … dist-tags` shows `rc`


Made with [Cursor](https://cursor.com)