### PR TITLE
hotfix: keep --tag rc, restore registry-url

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -80,8 +80,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 22
-          # Do not set registry-url here: it injects NODE_AUTH_TOKEN into .npmrc.
-          # Trusted Publishing (OIDC + id-token: write) must authenticate npm publish.
+          registry-url: https://registry.npmjs.org
 
       - name: Upgrade npm for Trusted Publishing
         run: npm install -g npm@latest
@@ -131,10 +130,6 @@ jobs:
             publish_args+=(--tag rc)
             echo "prerelease detected (${version}); using --tag rc"
           fi
-          # Prefer Trusted Publishing (OIDC). A stale/bypass-2FA token in
-          # NODE_AUTH_TOKEN causes PUT 404 and blocks provenance-based publish.
-          unset NODE_AUTH_TOKEN
-          npm config delete "//registry.npmjs.org/:_authToken" >/dev/null 2>&1 || true
           npm publish "$tgz" "${publish_args[@]}"
 
       - name: Publish @b4moss/jp-local-gov-id
@@ -173,6 +168,4 @@ jobs:
             publish_args+=(--tag rc)
             echo "prerelease detected (${version}); using --tag rc"
           fi
-          unset NODE_AUTH_TOKEN
-          npm config delete "//registry.npmjs.org/:_authToken" >/dev/null 2>&1 || true
           npm publish "$tgz" "${publish_args[@]}"


### PR DESCRIPTION
## Summary
- Keep prerelease `--tag rc` (fixes original publish error)
- Restore `registry-url` because removing it caused `ENEEDAUTH` (Trusted Publishing OIDC is not authenticating publishes today)
- Drop experimental `unset NODE_AUTH_TOKEN` so the workflow is not left in a worse state

## Remaining (manual)
npm auth still fails with token `E404` / OIDC `ENEEDAUTH`. Re-check Trusted Publishers + automation token on npmjs.com, then retag/re-release.


Made with [Cursor](https://cursor.com)