### PR TITLE
Bump RC: data 1.0.0-rc.3 / app 1.0.0-rc.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ A monorepo for Japan’s nationwide local government codes (npm workspaces).
 
 | Package | Description | Version |
 |---------|-------------|---------|
-| [`@b4moss/jp-local-gov-id`](./packages/jp-local-gov-id) | JS API (data not bundled; lazy-loaded) | 1.0.0-rc.1 |
-| [`@b4moss/jp-local-gov-id-data`](./packages/jp-local-gov-id-data) | Split JSON datasets | 1.0.0-rc.2 |
+| [`@b4moss/jp-local-gov-id`](./packages/jp-local-gov-id) | JS API (data not bundled; lazy-loaded) | 1.0.0-rc.2 |
+| [`@b4moss/jp-local-gov-id-data`](./packages/jp-local-gov-id-data) | Split JSON datasets | 1.0.0-rc.3 |
 
 ## Install (consumers)
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -15,8 +15,8 @@
 
 | パッケージ | 説明 | バージョン |
 |------------|------|------------|
-| [`@b4moss/jp-local-gov-id`](./packages/jp-local-gov-id) | JS API（データ非同梱・遅延ロード） | 1.0.0-rc.1 |
-| [`@b4moss/jp-local-gov-id-data`](./packages/jp-local-gov-id-data) | 分割データ JSON | 1.0.0-rc.2 |
+| [`@b4moss/jp-local-gov-id`](./packages/jp-local-gov-id) | JS API（データ非同梱・遅延ロード） | 1.0.0-rc.2 |
+| [`@b4moss/jp-local-gov-id-data`](./packages/jp-local-gov-id-data) | 分割データ JSON | 1.0.0-rc.3 |
 
 ## インストール（利用側）
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -19548,7 +19548,7 @@
     },
     "packages/jp-local-gov-id-data": {
       "name": "@b4moss/jp-local-gov-id-data",
-      "version": "1.0.0-rc.2",
+      "version": "1.0.0-rc.3",
       "license": "MIT"
     },
     "scripts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19538,7 +19538,7 @@
       "version": "1.0.0-rc.2",
       "license": "MIT",
       "devDependencies": {
-        "@b4moss/jp-local-gov-id-data": "1.0.0-rc.2",
+        "@b4moss/jp-local-gov-id-data": "1.0.0-rc.3",
         "@vitest/coverage-v8": "^4",
         "typescript": "^5.8.3",
         "vite": "^6.3.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19535,7 +19535,7 @@
     },
     "packages/jp-local-gov-id": {
       "name": "@b4moss/jp-local-gov-id",
-      "version": "1.0.0-rc.1",
+      "version": "1.0.0-rc.2",
       "license": "MIT",
       "devDependencies": {
         "@b4moss/jp-local-gov-id-data": "1.0.0-rc.2",

--- a/packages/jp-local-gov-id-data/package.json
+++ b/packages/jp-local-gov-id-data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@b4moss/jp-local-gov-id-data",
-  "version": "1.0.0-rc.2",
+  "version": "1.0.0-rc.3",
   "description": "日本の全国地方公共団体コードのデータ（分割 JSON）",
   "type": "module",
   "main": "./dataset.js",

--- a/packages/jp-local-gov-id/package.json
+++ b/packages/jp-local-gov-id/package.json
@@ -38,7 +38,7 @@
     "access": "public"
   },
   "devDependencies": {
-    "@b4moss/jp-local-gov-id-data": "1.0.0-rc.2",
+    "@b4moss/jp-local-gov-id-data": "1.0.0-rc.3",
     "typescript": "^5.8.3",
     "vite": "^6.3.5",
     "vite-plugin-dts": "^4.5.4",

--- a/packages/jp-local-gov-id/package.json
+++ b/packages/jp-local-gov-id/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@b4moss/jp-local-gov-id",
-  "version": "1.0.0-rc.1",
+  "version": "1.0.0-rc.2",
   "description": "日本の全国地方公共団体コードを扱う npm パッケージ",
   "type": "module",
   "main": "./dist/jp-local-gov-id.js",

--- a/site/content/en/installation.md
+++ b/site/content/en/installation.md
@@ -32,10 +32,10 @@ Prefer loading split JSON via `url` rather than bundling `dataset.js`.
 <html lang="en">
   <body>
     <script type="module">
-      import { createLocalGovClient } from "https://cdn.jsdelivr.net/npm/@b4moss/jp-local-gov-id@0.6.0/dist/jp-local-gov-id.js";
+      import { createLocalGovClient } from "https://cdn.jsdelivr.net/npm/@b4moss/jp-local-gov-id@1.0.0-rc.2/dist/jp-local-gov-id.js";
 
       const client = await createLocalGovClient({
-        url: "https://cdn.jsdelivr.net/npm/@b4moss/jp-local-gov-id-data@1.0.0-rc.1/index.json",
+        url: "https://cdn.jsdelivr.net/npm/@b4moss/jp-local-gov-id-data@1.0.0-rc.3/index.json",
       });
 
       console.log(await client.getByCode("131016"));

--- a/site/content/ja/installation.md
+++ b/site/content/ja/installation.md
@@ -32,10 +32,10 @@ npm / Vite / webpack を使わず、ブラウザから直接読み込むこと�
 <html lang="ja">
   <body>
     <script type="module">
-      import { createLocalGovClient } from "https://cdn.jsdelivr.net/npm/@b4moss/jp-local-gov-id@0.6.0/dist/jp-local-gov-id.js";
+      import { createLocalGovClient } from "https://cdn.jsdelivr.net/npm/@b4moss/jp-local-gov-id@1.0.0-rc.2/dist/jp-local-gov-id.js";
 
       const client = await createLocalGovClient({
-        url: "https://cdn.jsdelivr.net/npm/@b4moss/jp-local-gov-id-data@1.0.0-rc.1/index.json",
+        url: "https://cdn.jsdelivr.net/npm/@b4moss/jp-local-gov-id-data@1.0.0-rc.3/index.json",
       });
 
       console.log(await client.getByCode("131016"));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Bump `@b4moss/jp-local-gov-id-data` to `1.0.0-rc.3` and `@b4moss/jp-local-gov-id` to `1.0.0-rc.2`
- Point the API package at data `1.0.0-rc.3` and sync `package-lock.json`
- Update README version tables and CDN install examples

## Release plan
After merge to `develop` → `main` → `release`, tag on `main`:
- `data-v1.0.0-rc.3`
- `app-v1.0.0-rc.2`

Publish uses `--tag rc` (does not move `latest`).

Closes #34
Closes #35

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a042ba-067d-7f79-ae74-a3b58257faea?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a042ba-067d-7f79-ae74-a3b58257faea&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

