### PR TITLE
Pin development and CI to Node.js 24 (#23 #44 #54)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,13 @@
+{
+  "name": "jp-local-gov-id",
+  "image": "mcr.microsoft.com/devcontainers/javascript-node:24",
+  "postCreateCommand": "npm ci",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "editorconfig.editorconfig",
+        "vitest.explorer"
+      ]
+    }
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
 
       - name: Install dependencies

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
 
       - name: Setup Pages

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           registry-url: https://registry.npmjs.org
 
       - name: Upgrade npm for Trusted Publishing

--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
     "publish:dry-run": "node scripts/publish-package.mjs packages/jp-local-gov-id-data --dry-run && node scripts/publish-package.mjs packages/jp-local-gov-id --dry-run"
   },
   "license": "MIT",
+  "engines": {
+    "node": ">=24"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/b4moss/jp-local-gov-id"

--- a/packages/jp-local-gov-id-data/package.json
+++ b/packages/jp-local-gov-id-data/package.json
@@ -33,6 +33,9 @@
     "prefecture"
   ],
   "license": "MIT",
+  "engines": {
+    "node": ">=24"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/b4moss/jp-local-gov-id",

--- a/packages/jp-local-gov-id/package.json
+++ b/packages/jp-local-gov-id/package.json
@@ -29,6 +29,9 @@
     "prefecture"
   ],
   "license": "MIT",
+  "engines": {
+    "node": ">=24"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/b4moss/jp-local-gov-id",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Bump GitHub Actions `node-version` from 22 to 24 in CI, deploy-docs, and publish workflows
- Add `"engines": { "node": ">=24" }` to root, API, and data packages (interim floor until minimum runtime is researched)
- Add `.devcontainer/devcontainer.json` on the official Node 24 image

Milestone: `app-v1.0.0-rc.2`

## Verification
- Node.js v24.20.0: `npm ci` / `npm test` (61 passed) / `npm run build` OK
- `npm run build:site` OK

Closes #23
Closes #44
Closes #54

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a042c0-6cfe-78c1-9152-e318cd553604?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a042c0-6cfe-78c1-9152-e318cd553604&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

