### PR TITLE
fix(site): header versions use npm latest including rc

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,10 @@
         "packages/*",
         "scripts",
         "site"
-      ]
+      ],
+      "engines": {
+        "node": ">=24"
+      }
     },
     "node_modules/@apidevtools/json-schema-ref-parser": {
       "version": "14.2.1",
@@ -6182,6 +6185,13 @@
       "version": "1.20.2",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
       "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
+      "license": "MIT"
+    },
+    "node_modules/@types/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-1mAINjtQCXXeLkJ9ehXkwOcBpqtLxiVtKhpUf83DdRNdQKV0iXZpaHYqRr7nj+wvxuJzoAmAwXI+sCNMv1CzLQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/unist": {
@@ -19544,12 +19554,18 @@
         "vite": "^6.3.5",
         "vite-plugin-dts": "^4.5.4",
         "vitest": "^4.1.10"
+      },
+      "engines": {
+        "node": ">=24"
       }
     },
     "packages/jp-local-gov-id-data": {
       "name": "@b4moss/jp-local-gov-id-data",
       "version": "1.0.0-rc.3",
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=24"
+      }
     },
     "scripts": {
       "name": "jp-local-gov-id-scripts",
@@ -19573,9 +19589,13 @@
         "@nuxtjs/i18n": "^9.5.6",
         "codemirror": "^6.0.2",
         "nuxt": "^4.4.8",
+        "semver": "^7.8.5",
         "sucrase": "^3.35.0",
         "vue": "^3.5.35",
         "vue-router": "^5.1.0"
+      },
+      "devDependencies": {
+        "@types/semver": "^7.8.0"
       }
     },
     "site/node_modules/@babel/generator": {
@@ -19723,6 +19743,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sxzz"
+      }
+    },
+    "site/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "site/node_modules/vite": {

--- a/site/nuxt.config.ts
+++ b/site/nuxt.config.ts
@@ -1,6 +1,7 @@
 import { copyFileSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { gt, valid } from "semver";
 
 const rootDir = join(dirname(fileURLToPath(import.meta.url)), "..");
 
@@ -11,9 +12,49 @@ function readPackageVersion(relativePath: string) {
   return pkg.version;
 }
 
-const appVersion = readPackageVersion("packages/jp-local-gov-id/package.json");
-const dataVersion = readPackageVersion(
+/** Prefer the newer of npm `latest` and `rc` (RC-inclusive latest). */
+function pickLatestIncludingRc(versions: Array<string | undefined>): string | null {
+  let best: string | null = null;
+  for (const raw of versions) {
+    if (!raw || !valid(raw)) continue;
+    if (!best || gt(raw, best)) best = raw;
+  }
+  return best;
+}
+
+async function resolveNpmLatestIncludingRc(
+  packageName: string,
+  fallback: string,
+): Promise<string> {
+  try {
+    const res = await fetch(
+      `https://registry.npmjs.org/${encodeURIComponent(packageName)}`,
+    );
+    if (!res.ok) return fallback;
+    const data = (await res.json()) as {
+      "dist-tags"?: Record<string, string>;
+    };
+    const tags = data["dist-tags"] ?? {};
+    return pickLatestIncludingRc([tags.latest, tags.rc]) ?? fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+const packageAppVersion = readPackageVersion(
+  "packages/jp-local-gov-id/package.json",
+);
+const packageDataVersion = readPackageVersion(
   "packages/jp-local-gov-id-data/package.json",
+);
+
+const appVersion = await resolveNpmLatestIncludingRc(
+  "@b4moss/jp-local-gov-id",
+  packageAppVersion,
+);
+const dataVersion = await resolveNpmLatestIncludingRc(
+  "@b4moss/jp-local-gov-id-data",
+  packageDataVersion,
 );
 
 // https://nuxt.com/docs/api/configuration/nuxt-config

--- a/site/package.json
+++ b/site/package.json
@@ -20,8 +20,12 @@
     "@nuxtjs/i18n": "^9.5.6",
     "codemirror": "^6.0.2",
     "nuxt": "^4.4.8",
+    "semver": "^7.8.5",
     "sucrase": "^3.35.0",
     "vue": "^3.5.35",
     "vue-router": "^5.1.0"
+  },
+  "devDependencies": {
+    "@types/semver": "^7.8.0"
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- ロゴ横の `app-` / `data-` バージョンを、npm の `latest` タグ（stable）だけではなく、`latest` と `rc` の新しい方（RC 込みの latest）から解決するように変更
- レジストリ取得に失敗した場合は monorepo の `package.json` にフォールバック
- この変更を取り込み後、`site-v1.0.0-doc.1` で docs をデプロイ予定

## Test plan
- [x] `nuxt generate` で `appVersion: 1.0.0-rc.2` / `dataVersion: 1.0.0-rc.3` が焼けること
- [ ] CI 緑
- [ ] merge 後に `site-v1.0.0-doc.1` を push して Deploy Docs 成功

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a042e2-4b9e-7e28-83f7-31853d19d9a0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a042e2-4b9e-7e28-83f7-31853d19d9a0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

