### PR TITLE
feat(binary): #73 JLPR/JLDT encode/decode

### DIFF
--- a/packages/jp-local-gov-id/src/binary/binary.test.ts
+++ b/packages/jp-local-gov-id/src/binary/binary.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from "vitest";
+import {
+  BINARY_FORMAT_VERSION,
+  decodeMunicipalities,
+  decodeMunicipalitiesFile,
+  decodePrefectures,
+  decodePrefecturesFile,
+  encodeMunicipalities,
+  encodePrefectures,
+  LocalGovBinaryError,
+  MAGIC_JLDT,
+  MAGIC_JLPR,
+  MUNICIPALITY_RECORD_SIZE,
+  PREFECTURE_RECORD_SIZE,
+  type MunicipalityBinRecord,
+  type PrefectureBinRecord,
+} from "./index";
+
+const samplePrefs: PrefectureBinRecord[] = [
+  {
+    prefCode: 1,
+    name: "北海道",
+    nameKana: "ﾎｯｶｲﾄﾞｳ",
+    muniCode: 10006,
+    muniCountBoth: 195,
+    muniCountCity: 185,
+    muniCountWard: 194,
+  },
+  {
+    prefCode: 27,
+    name: "大阪府",
+    nameKana: "ｵｵｻｶﾌ",
+    muniCode: 270008,
+    muniCountBoth: 74,
+    muniCountCity: 43,
+    muniCountWard: 72,
+  },
+];
+
+const sampleMunis: MunicipalityBinRecord[] = [
+  {
+    code: 11002,
+    name: "札幌市",
+    nameKana: "ｻｯﾎﾟﾛｼ",
+    hasWard: 1,
+    isWard: 0,
+  },
+  {
+    code: 11011,
+    name: "札幌市中央区",
+    nameKana: "ｻｯﾎﾟﾛｼﾁｭｳｵｳｸ",
+    hasWard: 0,
+    isWard: 1,
+  },
+];
+
+describe("binary constants (TC-B03)", () => {
+  it("record sizes match ksy / issue #73", () => {
+    expect(PREFECTURE_RECORD_SIZE).toBe(16);
+    expect(1 + 4 + 4 + 4 + 1 + 1 + 1).toBe(PREFECTURE_RECORD_SIZE);
+    expect(MUNICIPALITY_RECORD_SIZE).toBe(14);
+    expect(4 + 4 + 4 + 1 + 1).toBe(MUNICIPALITY_RECORD_SIZE);
+  });
+});
+
+describe("JLPR (TC-B01)", () => {
+  it("round-trips prefecture records", () => {
+    const buf = encodePrefectures(samplePrefs, { asOf: "R6.1.1" });
+    const decoded = decodePrefectures(buf);
+    expect(decoded.version).toBe(BINARY_FORMAT_VERSION);
+    expect(decoded.asOf).toBe("R6.1.1");
+    expect(decoded.records).toEqual(samplePrefs);
+
+    const file = decodePrefecturesFile(buf);
+    expect(file.schemaVersion).toBe(1);
+    expect(file.prefectures[0]).toMatchObject({
+      code: "01",
+      prefectureCode: "01",
+      name: "北海道",
+      municipalityCounts: { both: 195, city: 185, ward: 194 },
+    });
+    expect(file.prefectures[1].code).toBe("27");
+    expect(file.prefectures[0]).not.toHaveProperty("hasWard");
+    expect(file.prefectures[0]).not.toHaveProperty("muniCode");
+  });
+});
+
+describe("JLDT (TC-B02)", () => {
+  it("round-trips municipality records without exposing flags publicly", () => {
+    const buf = encodeMunicipalities(sampleMunis, { asOf: "R6.1.1" });
+    const decoded = decodeMunicipalities(buf);
+    expect(decoded.records).toEqual(sampleMunis);
+
+    const file = decodeMunicipalitiesFile(buf, {
+      prefectureCode: "01",
+      prefectureName: "北海道",
+      prefectureNameKana: "ﾎｯｶｲﾄﾞｳ",
+    });
+    expect(file.municipalities[0]).toEqual({
+      code: "011002",
+      name: "札幌市",
+      nameKana: "ｻｯﾎﾟﾛｼ",
+      prefectureCode: "01",
+      prefectureName: "北海道",
+      prefectureNameKana: "ﾎｯｶｲﾄﾞｳ",
+    });
+    expect(file.municipalities[0]).not.toHaveProperty("hasWard");
+    expect(file.municipalities[0]).not.toHaveProperty("isWard");
+  });
+});
+
+describe("string table sharing (TC-B04)", () => {
+  it("reuses offsets for identical strings", () => {
+    const records: PrefectureBinRecord[] = [
+      {
+        prefCode: 1,
+        name: "同名",
+        nameKana: "ﾄﾞｳﾒｲ",
+        muniCode: 1,
+        muniCountBoth: 1,
+        muniCountCity: 1,
+        muniCountWard: 1,
+      },
+      {
+        prefCode: 2,
+        name: "同名",
+        nameKana: "ﾄﾞｳﾒｲ",
+        muniCode: 2,
+        muniCountBoth: 1,
+        muniCountCity: 1,
+        muniCountWard: 1,
+      },
+    ];
+    const buf = encodePrefectures(records, { asOf: "R6.1.1" });
+    const view = new DataView(buf);
+    const asOfLen = view.getUint8(5);
+    const recordStart = 4 + 1 + 1 + asOfLen + 2;
+    const nameOff0 = view.getUint32(recordStart + 1, true);
+    const kanaOff0 = view.getUint32(recordStart + 5, true);
+    const nameOff1 = view.getUint32(recordStart + PREFECTURE_RECORD_SIZE + 1, true);
+    const kanaOff1 = view.getUint32(recordStart + PREFECTURE_RECORD_SIZE + 5, true);
+    expect(nameOff0).toBe(nameOff1);
+    expect(kanaOff0).toBe(kanaOff1);
+    expect(nameOff0).not.toBe(kanaOff0);
+  });
+});
+
+describe("strict decode errors", () => {
+  it("TC-B05: invalid magic", () => {
+    const buf = encodePrefectures(samplePrefs, { asOf: "R6.1.1" });
+    const bytes = new Uint8Array(buf.slice(0));
+    bytes[0] = 0x00;
+    expect(() => decodePrefectures(bytes.buffer)).toThrow(LocalGovBinaryError);
+  });
+
+  it("TC-B06: unsupported version", () => {
+    const buf = encodePrefectures(samplePrefs, { asOf: "R6.1.1" });
+    const bytes = new Uint8Array(buf.slice(0));
+    bytes[4] = 2;
+    expect(() => decodePrefectures(bytes.buffer)).toThrow(/Unsupported version/);
+  });
+
+  it("TC-B07: truncated buffer", () => {
+    const buf = encodePrefectures(samplePrefs, { asOf: "R6.1.1" });
+    const truncated = buf.slice(0, 8);
+    expect(() => decodePrefectures(truncated)).toThrow(LocalGovBinaryError);
+  });
+
+  it("TC-B08: bad string offset", () => {
+    const buf = encodePrefectures(samplePrefs, { asOf: "R6.1.1" });
+    const copy = buf.slice(0);
+    const view = new DataView(copy);
+    const asOfLen = view.getUint8(5);
+    const recordStart = 4 + 1 + 1 + asOfLen + 2;
+    view.setUint32(recordStart + 1, 0xffffff, true);
+    expect(() => decodePrefectures(copy)).toThrow(LocalGovBinaryError);
+  });
+
+  it("TC-B09: trailing bytes", () => {
+    const buf = encodePrefectures(samplePrefs, { asOf: "R6.1.1" });
+    const withTrailing = new Uint8Array(buf.byteLength + 1);
+    withTrailing.set(new Uint8Array(buf));
+    withTrailing[withTrailing.length - 1] = 0xff;
+    expect(() => decodePrefectures(withTrailing.buffer)).toThrow(
+      /trailing or unused bytes/,
+    );
+  });
+
+  it("TC-B10: magic strings", () => {
+    expect(MAGIC_JLPR).toBe("JLPR");
+    expect(MAGIC_JLDT).toBe("JLDT");
+  });
+});

--- a/packages/jp-local-gov-id/src/binary/constants.ts
+++ b/packages/jp-local-gov-id/src/binary/constants.ts
@@ -1,0 +1,18 @@
+/** Binary format constants for JLPR / JLDT (Issue #73). */
+
+export const BINARY_FORMAT_VERSION = 1;
+
+export const MAGIC_JLPR = "JLPR";
+export const MAGIC_JLDT = "JLDT";
+
+export const MAGIC_JLPR_BYTES = new Uint8Array([0x4a, 0x4c, 0x50, 0x52]);
+export const MAGIC_JLDT_BYTES = new Uint8Array([0x4a, 0x4c, 0x44, 0x54]);
+
+/** Prefecture fixed record: u1 + u4 + u4 + u4 + u1 + u1 + u1 */
+export const PREFECTURE_RECORD_SIZE = 16;
+
+/** Municipality fixed record: u4 + u4 + u4 + u1 + u1 */
+export const MUNICIPALITY_RECORD_SIZE = 14;
+
+/** Logical schemaVersion on decoded envelopes (unchanged from JSON era). */
+export const DECODED_SCHEMA_VERSION = 1;

--- a/packages/jp-local-gov-id/src/binary/errors.ts
+++ b/packages/jp-local-gov-id/src/binary/errors.ts
@@ -1,0 +1,7 @@
+export class LocalGovBinaryError extends Error {
+  override readonly name = "LocalGovBinaryError";
+
+  constructor(message: string) {
+    super(message);
+  }
+}

--- a/packages/jp-local-gov-id/src/binary/index.ts
+++ b/packages/jp-local-gov-id/src/binary/index.ts
@@ -1,0 +1,33 @@
+export {
+  BINARY_FORMAT_VERSION,
+  DECODED_SCHEMA_VERSION,
+  MAGIC_JLDT,
+  MAGIC_JLDT_BYTES,
+  MAGIC_JLPR,
+  MAGIC_JLPR_BYTES,
+  MUNICIPALITY_RECORD_SIZE,
+  PREFECTURE_RECORD_SIZE,
+} from "./constants";
+export { LocalGovBinaryError } from "./errors";
+export {
+  decodeMunicipalities,
+  decodeMunicipalitiesFile,
+  encodeMunicipalities,
+  municipalityRecordToLocalGov,
+  prefectureCodeFromMunicipalityCode,
+  toMunicipalitiesFile,
+  type DecodedMunicipalitiesBin,
+  type EncodeMunicipalitiesMeta,
+  type MunicipalityBinRecord,
+  type PrefectureNameLookup,
+} from "./municipalities";
+export {
+  decodePrefectures,
+  decodePrefecturesFile,
+  encodePrefectures,
+  prefectureRecordToLocalGov,
+  toPrefecturesFile,
+  type DecodedPrefecturesBin,
+  type EncodePrefecturesMeta,
+  type PrefectureBinRecord,
+} from "./prefectures";

--- a/packages/jp-local-gov-id/src/binary/municipalities.ts
+++ b/packages/jp-local-gov-id/src/binary/municipalities.ts
@@ -1,0 +1,247 @@
+import type { LocalGov, LocalGovMunicipalitiesFile } from "../types";
+import {
+  BINARY_FORMAT_VERSION,
+  DECODED_SCHEMA_VERSION,
+  MAGIC_JLDT,
+  MAGIC_JLDT_BYTES,
+  MUNICIPALITY_RECORD_SIZE,
+} from "./constants";
+import { LocalGovBinaryError } from "./errors";
+import {
+  assertMagic,
+  createStringTableBuilder,
+  encodeUtf8,
+  readCString,
+} from "./stringTable";
+
+/** Wire-format municipality record (includes internal flags). */
+export type MunicipalityBinRecord = {
+  code: number;
+  name: string;
+  nameKana: string;
+  hasWard: 0 | 1;
+  isWard: 0 | 1;
+};
+
+export type EncodeMunicipalitiesMeta = {
+  version?: number;
+  asOf: string;
+};
+
+export type DecodedMunicipalitiesBin = {
+  version: number;
+  asOf: string;
+  records: MunicipalityBinRecord[];
+};
+
+export type PrefectureNameLookup = {
+  prefectureCode: string;
+  prefectureName: string;
+  prefectureNameKana: string;
+};
+
+function requireU8Flag(n: number, field: string): 0 | 1 {
+  if (n !== 0 && n !== 1) {
+    throw new LocalGovBinaryError(`${field} must be 0 or 1: ${n}`);
+  }
+  return n;
+}
+
+function requireU32(n: number, field: string): number {
+  if (!Number.isInteger(n) || n < 0 || n > 0xffff_ffff) {
+    throw new LocalGovBinaryError(`${field} out of u4 range: ${n}`);
+  }
+  return n;
+}
+
+function stringEndExclusive(
+  bytes: Uint8Array,
+  stringTableOffset: number,
+  relativeOffset: number,
+  endExclusive: number,
+): number {
+  readCString(bytes, stringTableOffset, relativeOffset, endExclusive);
+  let p = stringTableOffset + relativeOffset;
+  while (bytes[p] !== 0) p++;
+  return p + 1;
+}
+
+function assertPayloadEndsAt(
+  label: string,
+  expectedEnd: number,
+  actualEnd: number,
+): void {
+  if (expectedEnd !== actualEnd) {
+    throw new LocalGovBinaryError(
+      `${label}: trailing or unused bytes (expected end ${expectedEnd}, got ${actualEnd})`,
+    );
+  }
+}
+
+export function encodeMunicipalities(
+  records: MunicipalityBinRecord[],
+  meta: EncodeMunicipalitiesMeta,
+): ArrayBuffer {
+  const version = meta.version ?? BINARY_FORMAT_VERSION;
+  if (!Number.isInteger(version) || version < 0 || version > 0xff) {
+    throw new LocalGovBinaryError(`version out of u1 range: ${version}`);
+  }
+  const asOfBytes = encodeUtf8(meta.asOf);
+  if (asOfBytes.length > 0xff) {
+    throw new LocalGovBinaryError("asOf exceeds u1 length");
+  }
+  if (records.length > 0xffff) {
+    throw new LocalGovBinaryError("record_count exceeds u2");
+  }
+
+  const strings = createStringTableBuilder();
+  const encoded = records.map((record) => ({
+    code: requireU32(record.code, "code"),
+    nameOffset: strings.add(record.name),
+    nameKanaOffset: strings.add(record.nameKana),
+    hasWard: requireU8Flag(record.hasWard, "hasWard"),
+    isWard: requireU8Flag(record.isWard, "isWard"),
+  }));
+
+  const headerSize = 4 + 1 + 1 + asOfBytes.length + 2;
+  const total =
+    headerSize +
+    MUNICIPALITY_RECORD_SIZE * encoded.length +
+    strings.byteLength;
+  const buffer = new ArrayBuffer(total);
+  const view = new DataView(buffer);
+  const bytes = new Uint8Array(buffer);
+
+  let pos = 0;
+  bytes.set(MAGIC_JLDT_BYTES, pos);
+  pos += 4;
+  view.setUint8(pos++, version);
+  view.setUint8(pos++, asOfBytes.length);
+  bytes.set(asOfBytes, pos);
+  pos += asOfBytes.length;
+  view.setUint16(pos, encoded.length, true);
+  pos += 2;
+
+  for (const record of encoded) {
+    view.setUint32(pos, record.code, true);
+    pos += 4;
+    view.setUint32(pos, record.nameOffset, true);
+    pos += 4;
+    view.setUint32(pos, record.nameKanaOffset, true);
+    pos += 4;
+    view.setUint8(pos++, record.hasWard);
+    view.setUint8(pos++, record.isWard);
+  }
+
+  const end = strings.writeTo(bytes, pos);
+  if (end !== total) {
+    throw new LocalGovBinaryError("Internal encode size mismatch (JLDT)");
+  }
+  return buffer;
+}
+
+export function decodeMunicipalities(
+  buffer: ArrayBuffer,
+): DecodedMunicipalitiesBin {
+  const bytes = new Uint8Array(buffer);
+  const view = new DataView(buffer);
+  const end = bytes.length;
+
+  assertMagic(bytes, MAGIC_JLDT, "JLDT");
+  let pos = 4;
+
+  if (pos + 2 > end) {
+    throw new LocalGovBinaryError("JLDT: buffer too short for version/asOfLen");
+  }
+  const version = view.getUint8(pos++);
+  if (version !== BINARY_FORMAT_VERSION) {
+    throw new LocalGovBinaryError(`Unsupported version: ${version}`);
+  }
+  const asOfLen = view.getUint8(pos++);
+  if (pos + asOfLen + 2 > end) {
+    throw new LocalGovBinaryError("JLDT: buffer too short for asOf/record_count");
+  }
+  const asOf = new TextDecoder().decode(bytes.subarray(pos, pos + asOfLen));
+  pos += asOfLen;
+  const recordCount = view.getUint16(pos, true);
+  pos += 2;
+
+  const recordsByteLength = MUNICIPALITY_RECORD_SIZE * recordCount;
+  if (pos + recordsByteLength > end) {
+    throw new LocalGovBinaryError("JLDT: buffer too short for records");
+  }
+  const stringTableOffset = pos + recordsByteLength;
+
+  const records: MunicipalityBinRecord[] = [];
+  let payloadEnd = stringTableOffset;
+  for (let i = 0; i < recordCount; i++) {
+    const code = view.getUint32(pos, true);
+    pos += 4;
+    const nameOffset = view.getUint32(pos, true);
+    pos += 4;
+    const nameKanaOffset = view.getUint32(pos, true);
+    pos += 4;
+    const hasWard = requireU8Flag(view.getUint8(pos++), "hasWard");
+    const isWard = requireU8Flag(view.getUint8(pos++), "isWard");
+
+    const name = readCString(bytes, stringTableOffset, nameOffset, end);
+    const nameKana = readCString(bytes, stringTableOffset, nameKanaOffset, end);
+    payloadEnd = Math.max(
+      payloadEnd,
+      stringEndExclusive(bytes, stringTableOffset, nameOffset, end),
+      stringEndExclusive(bytes, stringTableOffset, nameKanaOffset, end),
+    );
+
+    records.push({ code, name, nameKana, hasWard, isWard });
+  }
+
+  if (recordCount === 0) {
+    assertPayloadEndsAt("JLDT", stringTableOffset, end);
+  } else {
+    assertPayloadEndsAt("JLDT", payloadEnd, end);
+  }
+
+  return { version, asOf, records };
+}
+
+export function municipalityRecordToLocalGov(
+  record: MunicipalityBinRecord,
+  pref: PrefectureNameLookup,
+): LocalGov {
+  const code = String(record.code).padStart(6, "0");
+  return {
+    code,
+    name: record.name,
+    nameKana: record.nameKana,
+    prefectureCode: pref.prefectureCode,
+    prefectureName: pref.prefectureName,
+    prefectureNameKana: pref.prefectureNameKana,
+  };
+}
+
+export function toMunicipalitiesFile(
+  decoded: DecodedMunicipalitiesBin,
+  pref: PrefectureNameLookup,
+): LocalGovMunicipalitiesFile {
+  return {
+    schemaVersion: DECODED_SCHEMA_VERSION,
+    asOf: decoded.asOf,
+    prefectureCode: pref.prefectureCode,
+    municipalities: decoded.records.map((r) =>
+      municipalityRecordToLocalGov(r, pref),
+    ),
+  };
+}
+
+export function decodeMunicipalitiesFile(
+  buffer: ArrayBuffer,
+  pref: PrefectureNameLookup,
+): LocalGovMunicipalitiesFile {
+  return toMunicipalitiesFile(decodeMunicipalities(buffer), pref);
+}
+
+/** Derive 2-digit prefecture code from a municipality local-gov code. */
+export function prefectureCodeFromMunicipalityCode(code: number | string): string {
+  const padded = String(code).padStart(6, "0");
+  return padded.slice(0, 2);
+}

--- a/packages/jp-local-gov-id/src/binary/prefectures.ts
+++ b/packages/jp-local-gov-id/src/binary/prefectures.ts
@@ -1,0 +1,247 @@
+import type { LocalGov, LocalGovPrefecturesFile, MunicipalityCounts } from "../types";
+import {
+  BINARY_FORMAT_VERSION,
+  DECODED_SCHEMA_VERSION,
+  MAGIC_JLPR,
+  MAGIC_JLPR_BYTES,
+  PREFECTURE_RECORD_SIZE,
+} from "./constants";
+import { LocalGovBinaryError } from "./errors";
+import {
+  assertMagic,
+  createStringTableBuilder,
+  encodeUtf8,
+  readCString,
+} from "./stringTable";
+
+/** Wire-format prefecture record (pre-normalization). */
+export type PrefectureBinRecord = {
+  prefCode: number;
+  name: string;
+  nameKana: string;
+  muniCode: number;
+  muniCountBoth: number;
+  muniCountCity: number;
+  muniCountWard: number;
+};
+
+export type EncodePrefecturesMeta = {
+  version?: number;
+  asOf: string;
+};
+
+export type DecodedPrefecturesBin = {
+  version: number;
+  asOf: string;
+  records: PrefectureBinRecord[];
+};
+
+function requireU8(n: number, field: string): number {
+  if (!Number.isInteger(n) || n < 0 || n > 0xff) {
+    throw new LocalGovBinaryError(`${field} out of u1 range: ${n}`);
+  }
+  return n;
+}
+
+function requireU32(n: number, field: string): number {
+  if (!Number.isInteger(n) || n < 0 || n > 0xffff_ffff) {
+    throw new LocalGovBinaryError(`${field} out of u4 range: ${n}`);
+  }
+  return n;
+}
+
+function stringEndExclusive(
+  bytes: Uint8Array,
+  stringTableOffset: number,
+  relativeOffset: number,
+  endExclusive: number,
+): number {
+  readCString(bytes, stringTableOffset, relativeOffset, endExclusive);
+  let p = stringTableOffset + relativeOffset;
+  while (bytes[p] !== 0) p++;
+  return p + 1;
+}
+
+function assertPayloadEndsAt(
+  label: string,
+  expectedEnd: number,
+  actualEnd: number,
+): void {
+  if (expectedEnd !== actualEnd) {
+    throw new LocalGovBinaryError(
+      `${label}: trailing or unused bytes (expected end ${expectedEnd}, got ${actualEnd})`,
+    );
+  }
+}
+
+export function encodePrefectures(
+  records: PrefectureBinRecord[],
+  meta: EncodePrefecturesMeta,
+): ArrayBuffer {
+  const version = meta.version ?? BINARY_FORMAT_VERSION;
+  requireU8(version, "version");
+  const asOfBytes = encodeUtf8(meta.asOf);
+  if (asOfBytes.length > 0xff) {
+    throw new LocalGovBinaryError("asOf exceeds u1 length");
+  }
+  if (records.length > 0xffff) {
+    throw new LocalGovBinaryError("record_count exceeds u2");
+  }
+
+  const strings = createStringTableBuilder();
+  const encoded = records.map((record) => ({
+    prefCode: requireU8(record.prefCode, "prefCode"),
+    nameOffset: strings.add(record.name),
+    nameKanaOffset: strings.add(record.nameKana),
+    muniCode: requireU32(record.muniCode, "muniCode"),
+    muniCountBoth: requireU8(record.muniCountBoth, "muniCountBoth"),
+    muniCountCity: requireU8(record.muniCountCity, "muniCountCity"),
+    muniCountWard: requireU8(record.muniCountWard, "muniCountWard"),
+  }));
+
+  const headerSize = 4 + 1 + 1 + asOfBytes.length + 2;
+  const total =
+    headerSize + PREFECTURE_RECORD_SIZE * encoded.length + strings.byteLength;
+  const buffer = new ArrayBuffer(total);
+  const view = new DataView(buffer);
+  const bytes = new Uint8Array(buffer);
+
+  let pos = 0;
+  bytes.set(MAGIC_JLPR_BYTES, pos);
+  pos += 4;
+  view.setUint8(pos++, version);
+  view.setUint8(pos++, asOfBytes.length);
+  bytes.set(asOfBytes, pos);
+  pos += asOfBytes.length;
+  view.setUint16(pos, encoded.length, true);
+  pos += 2;
+
+  for (const record of encoded) {
+    view.setUint8(pos, record.prefCode);
+    pos += 1;
+    view.setUint32(pos, record.nameOffset, true);
+    pos += 4;
+    view.setUint32(pos, record.nameKanaOffset, true);
+    pos += 4;
+    view.setUint32(pos, record.muniCode, true);
+    pos += 4;
+    view.setUint8(pos++, record.muniCountBoth);
+    view.setUint8(pos++, record.muniCountCity);
+    view.setUint8(pos++, record.muniCountWard);
+  }
+
+  const end = strings.writeTo(bytes, pos);
+  if (end !== total) {
+    throw new LocalGovBinaryError("Internal encode size mismatch (JLPR)");
+  }
+  return buffer;
+}
+
+export function decodePrefectures(buffer: ArrayBuffer): DecodedPrefecturesBin {
+  const bytes = new Uint8Array(buffer);
+  const view = new DataView(buffer);
+  const end = bytes.length;
+
+  assertMagic(bytes, MAGIC_JLPR, "JLPR");
+  let pos = 4;
+
+  if (pos + 2 > end) {
+    throw new LocalGovBinaryError("JLPR: buffer too short for version/asOfLen");
+  }
+  const version = view.getUint8(pos++);
+  if (version !== BINARY_FORMAT_VERSION) {
+    throw new LocalGovBinaryError(`Unsupported version: ${version}`);
+  }
+  const asOfLen = view.getUint8(pos++);
+  if (pos + asOfLen + 2 > end) {
+    throw new LocalGovBinaryError("JLPR: buffer too short for asOf/record_count");
+  }
+  const asOf = new TextDecoder().decode(bytes.subarray(pos, pos + asOfLen));
+  pos += asOfLen;
+  const recordCount = view.getUint16(pos, true);
+  pos += 2;
+
+  const recordsByteLength = PREFECTURE_RECORD_SIZE * recordCount;
+  if (pos + recordsByteLength > end) {
+    throw new LocalGovBinaryError("JLPR: buffer too short for records");
+  }
+  const stringTableOffset = pos + recordsByteLength;
+
+  const records: PrefectureBinRecord[] = [];
+  let payloadEnd = stringTableOffset;
+  for (let i = 0; i < recordCount; i++) {
+    const prefCode = view.getUint8(pos);
+    pos += 1;
+    const nameOffset = view.getUint32(pos, true);
+    pos += 4;
+    const nameKanaOffset = view.getUint32(pos, true);
+    pos += 4;
+    const muniCode = view.getUint32(pos, true);
+    pos += 4;
+    const muniCountBoth = view.getUint8(pos++);
+    const muniCountCity = view.getUint8(pos++);
+    const muniCountWard = view.getUint8(pos++);
+
+    const name = readCString(bytes, stringTableOffset, nameOffset, end);
+    const nameKana = readCString(bytes, stringTableOffset, nameKanaOffset, end);
+    payloadEnd = Math.max(
+      payloadEnd,
+      stringEndExclusive(bytes, stringTableOffset, nameOffset, end),
+      stringEndExclusive(bytes, stringTableOffset, nameKanaOffset, end),
+    );
+
+    records.push({
+      prefCode,
+      name,
+      nameKana,
+      muniCode,
+      muniCountBoth,
+      muniCountCity,
+      muniCountWard,
+    });
+  }
+
+  if (recordCount === 0) {
+    assertPayloadEndsAt("JLPR", stringTableOffset, end);
+  } else {
+    assertPayloadEndsAt("JLPR", payloadEnd, end);
+  }
+
+  return { version, asOf, records };
+}
+
+export function prefectureRecordToLocalGov(
+  record: PrefectureBinRecord,
+): LocalGov {
+  const code = String(record.prefCode).padStart(2, "0");
+  const counts: MunicipalityCounts = {
+    both: record.muniCountBoth,
+    city: record.muniCountCity,
+    ward: record.muniCountWard,
+  };
+  return {
+    code,
+    name: record.name,
+    nameKana: record.nameKana,
+    prefectureCode: code,
+    prefectureName: record.name,
+    prefectureNameKana: record.nameKana,
+    municipalityCounts: counts,
+  };
+}
+
+export function toPrefecturesFile(
+  decoded: DecodedPrefecturesBin,
+): LocalGovPrefecturesFile {
+  return {
+    schemaVersion: DECODED_SCHEMA_VERSION,
+    asOf: decoded.asOf,
+    prefectures: decoded.records.map(prefectureRecordToLocalGov),
+  };
+}
+
+export function decodePrefecturesFile(
+  buffer: ArrayBuffer,
+): LocalGovPrefecturesFile {
+  return toPrefecturesFile(decodePrefectures(buffer));
+}

--- a/packages/jp-local-gov-id/src/binary/stringTable.ts
+++ b/packages/jp-local-gov-id/src/binary/stringTable.ts
@@ -1,0 +1,90 @@
+import { LocalGovBinaryError } from "./errors";
+
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder();
+
+export type StringTableBuilder = {
+  add(value: string): number;
+  byteLength: number;
+  writeTo(bytes: Uint8Array, offset: number): number;
+};
+
+export function createStringTableBuilder(): StringTableBuilder {
+  const chunks: Uint8Array[] = [];
+  const offsets = new Map<string, number>();
+  let size = 0;
+
+  return {
+    add(value: string): number {
+      const existing = offsets.get(value);
+      if (existing !== undefined) return existing;
+      const encoded = textEncoder.encode(value);
+      const offset = size;
+      chunks.push(encoded);
+      offsets.set(value, offset);
+      size += encoded.length + 1;
+      return offset;
+    },
+    get byteLength() {
+      return size;
+    },
+    writeTo(bytes: Uint8Array, offset: number): number {
+      let pos = offset;
+      for (const chunk of chunks) {
+        bytes.set(chunk, pos);
+        pos += chunk.length;
+        bytes[pos++] = 0;
+      }
+      return pos;
+    },
+  };
+}
+
+export function readCString(
+  bytes: Uint8Array,
+  stringTableOffset: number,
+  relativeOffset: number,
+  endExclusive: number,
+): string {
+  if (relativeOffset < 0) {
+    throw new LocalGovBinaryError(`Invalid string offset: ${relativeOffset}`);
+  }
+  const start = stringTableOffset + relativeOffset;
+  if (start >= endExclusive) {
+    throw new LocalGovBinaryError(
+      `String offset out of range: ${relativeOffset}`,
+    );
+  }
+  let end = start;
+  while (end < endExclusive && bytes[end] !== 0) end++;
+  if (end >= endExclusive) {
+    throw new LocalGovBinaryError(
+      `Unterminated string at offset ${relativeOffset}`,
+    );
+  }
+  return textDecoder.decode(bytes.subarray(start, end));
+}
+
+export function encodeUtf8(value: string): Uint8Array {
+  return textEncoder.encode(value);
+}
+
+export function decodeUtf8(bytes: Uint8Array): string {
+  return textDecoder.decode(bytes);
+}
+
+export function assertMagic(
+  bytes: Uint8Array,
+  expected: string,
+  label: string,
+): void {
+  if (bytes.length < 4) {
+    throw new LocalGovBinaryError(`${label}: buffer too short for magic`);
+  }
+  const magic = decodeUtf8(bytes.subarray(0, 4));
+  if (magic !== expected) {
+    throw new LocalGovBinaryError(
+      `${label}: invalid magic (expected ${expected}, got ${JSON.stringify(magic)})`,
+    );
+  }
+}

--- a/packages/jp-local-gov-id/src/index.ts
+++ b/packages/jp-local-gov-id/src/index.ts
@@ -25,3 +25,24 @@ export {
   LocalGovSchemaError,
 } from "./schema";
 export { MUNICIPALITY_FETCH_CONCURRENCY } from "./pool";
+export {
+  BINARY_FORMAT_VERSION,
+  DECODED_SCHEMA_VERSION,
+  LocalGovBinaryError,
+  MAGIC_JLDT,
+  MAGIC_JLPR,
+  MUNICIPALITY_RECORD_SIZE,
+  PREFECTURE_RECORD_SIZE,
+  decodeMunicipalities,
+  decodeMunicipalitiesFile,
+  decodePrefectures,
+  decodePrefecturesFile,
+  encodeMunicipalities,
+  encodePrefectures,
+  prefectureCodeFromMunicipalityCode,
+} from "./binary";
+export type {
+  MunicipalityBinRecord,
+  PrefectureBinRecord,
+  PrefectureNameLookup,
+} from "./binary";

--- a/schema/local-government-code.ksy
+++ b/schema/local-government-code.ksy
@@ -1,0 +1,72 @@
+meta:
+  id: local_government_code
+  title: Japan local government code binary (JLPR / JLDT)
+  xref:
+    issue: 73
+  license: MIT
+  endian: le
+
+doc: |
+  Custom little-endian binary for @b4moss/jp-local-gov-id-data.
+  Two magics share a common header then fixed-size records and a NUL-terminated UTF-8 string table.
+  String offsets are relative to the start of the string table.
+  Identical strings must share one offset (encoder requirement).
+
+seq:
+  - id: magic
+    size: 4
+    type: str
+    encoding: ASCII
+  - id: version
+    type: u1
+  - id: as_of_len
+    type: u1
+  - id: as_of
+    size: as_of_len
+    type: str
+    encoding: UTF-8
+  - id: record_count
+    type: u2
+  - id: records
+    type:
+      switch-on: magic
+      cases:
+        '"JLPR"': prefecture_record
+        '"JLDT"': municipality_record
+    repeat: expr
+    repeat-expr: record_count
+  - id: string_table
+    size-eos: true
+
+types:
+  prefecture_record:
+    doc: Fixed 16-byte prefecture record (u1+u4+u4+u4+u1+u1+u1).
+    seq:
+      - id: pref_code
+        type: u1
+      - id: name_offset
+        type: u4
+      - id: name_kana_offset
+        type: u4
+      - id: muni_code
+        type: u4
+      - id: muni_count_both
+        type: u1
+      - id: muni_count_city
+        type: u1
+      - id: muni_count_ward
+        type: u1
+
+  municipality_record:
+    doc: Fixed 14-byte municipality record (u4+u4+u4+u1+u1).
+    seq:
+      - id: code
+        type: u4
+      - id: name_offset
+        type: u4
+      - id: name_kana_offset
+        type: u4
+      - id: has_ward
+        type: u1
+      - id: is_ward
+        type: u1


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Issue #73 向け JLPR / JLDT バイナリ codec（encode / decode）を追加
- `schema/local-government-code.ksy` を追加
- 厳格デコード（magic / version / 切り詰め / 不正 offset / 末尾余剰）と string table 共有の単体テスト（TC-B）
- 公開エンベロープ化（`schemaVersion: 1`、ゼロ埋め、フラグ非公開）

## Test plan

- [x] `npm run test -w @b4moss/jp-local-gov-id -- src/binary/binary.test.ts`
- [ ] 後続 generate / client PR から本 codec を利用

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a04bfd-ea6d-72f8-ae17-5235c0d55140?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a04bfd-ea6d-72f8-ae17-5235c0d55140&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

