### PR TITLE
ci: redesign CI/CD for develop/dev-* and local act gate

### DIFF
--- a/.actrc
+++ b/.actrc
@@ -1,0 +1,6 @@
+# Default act settings for local CI (nektos/act).
+# Prefer `npm run ci:local` before opening/updating PRs to develop / dev-*.
+# Requires Docker. Without Docker, use `npm run ci:local:fallback`.
+-P ubuntu-latest=catthehacker/ubuntu:act-latest
+--container-architecture linux/amd64
+-W .github/workflows/ci.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,19 +1,108 @@
+# CI — PRs targeting develop or dev-* only.
+# Local pre-PR gate: npm run ci:local (nektos/act). See docs/ci-cd.md.
 name: CI
 
 on:
-  push:
   pull_request:
+    branches:
+      - develop
+      - "dev-*"
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  actions: read
+  checks: read
+  pull-requests: read
+
 jobs:
+  gate:
+    name: Gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      skip_heavy: ${{ steps.decide.outputs.skip_heavy }}
+      reason: ${{ steps.decide.outputs.reason }}
+    steps:
+      - name: Decide skip / docs-only / full
+        id: decide
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const isAct = process.env.ACT === 'true';
+            if (isAct) {
+              core.setOutput('skip_heavy', 'false');
+              core.setOutput('reason', 'act');
+              core.info('ACT=true: always run heavy jobs');
+              return;
+            }
+
+            const pr = context.payload.pull_request;
+            if (!pr) {
+              core.setOutput('skip_heavy', 'false');
+              core.setOutput('reason', 'no-pr');
+              return;
+            }
+
+            const sha = pr.head.sha;
+            const base = context.repo;
+            const { data: runs } = await github.rest.actions.listWorkflowRuns({
+              owner: base.owner,
+              repo: base.repo,
+              workflow_id: 'ci.yml',
+              head_sha: sha,
+              status: 'completed',
+              per_page: 30,
+            });
+            const priorSuccess = (runs.workflow_runs || []).some(
+              (r) => r.conclusion === 'success' && String(r.id) !== String(context.runId),
+            );
+            if (priorSuccess) {
+              core.setOutput('skip_heavy', 'true');
+              core.setOutput('reason', 'sha-already-green');
+              core.info(`Skip heavy jobs: CI already succeeded for ${sha}`);
+              return;
+            }
+
+            // Docs-only path filter via compare API
+            const { data: comp } = await github.rest.repos.compareCommits({
+              owner: base.owner,
+              repo: base.repo,
+              base: pr.base.sha,
+              head: sha,
+            });
+            const files = comp.files || [];
+            const isDocsOnly =
+              files.length > 0 &&
+              files.every((f) => {
+                const p = f.filename;
+                return (
+                  p.startsWith('docs/') ||
+                  p.startsWith('site/content/') ||
+                  p.endsWith('.md') ||
+                  p === 'LICENSE' ||
+                  (p.startsWith('.github/') && p.endsWith('.md'))
+                );
+              });
+            if (isDocsOnly) {
+              core.setOutput('skip_heavy', 'true');
+              core.setOutput('reason', 'docs-only');
+              core.info('Skip heavy jobs: docs-only change set');
+              return;
+            }
+
+            core.setOutput('skip_heavy', 'false');
+            core.setOutput('reason', 'full');
+
   test:
-    name: Test & Build
+    name: Test
+    needs: gate
+    if: needs.gate.outputs.skip_heavy != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -31,6 +120,7 @@ jobs:
         run: npm test
 
       - name: Upload coverage to Codecov
+        if: ${{ !env.ACT }}
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -38,5 +128,51 @@ jobs:
           fail_ci_if_error: false
           verbose: true
 
+  build:
+    name: Build
+    needs: gate
+    if: needs.gate.outputs.skip_heavy != 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
       - name: Build
         run: npm run build
+
+  # Keeps branch-protection check name "Test & Build" stable.
+  result:
+    name: Test & Build
+    needs: [gate, test, build]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Aggregate
+        run: |
+          set -euo pipefail
+          skip='${{ needs.gate.outputs.skip_heavy }}'
+          reason='${{ needs.gate.outputs.reason }}'
+          test_result='${{ needs.test.result }}'
+          build_result='${{ needs.build.result }}'
+          echo "skip_heavy=${skip} reason=${reason}"
+          echo "test=${test_result} build=${build_result}"
+          if [ "${skip}" = "true" ]; then
+            echo "Heavy jobs skipped (${reason}); treating as success."
+            exit 0
+          fi
+          if [ "${test_result}" = "success" ] && [ "${build_result}" = "success" ]; then
+            exit 0
+          fi
+          echo "::error::Test and/or Build did not succeed"
+          exit 1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,171 +1,174 @@
-name: Publish
+# Publish packages to npm when a GitHub Release is published for data-v* / app-v*.
+# Tags should be created from the `release` branch. If the tag SHA already has a
+# successful CI run, Test/Build are skipped; pack + provenance publish always run.
+name: Publish packages
 
-# Release published routing (only the matching package):
-#   data-v* → @b4moss/jp-local-gov-id-data
-#   app-v*  → @b4moss/jp-local-gov-id
-#
-# Tag push alone does not publish; create and publish a GitHub Release.
-# Manual workflow_dispatch is also available.
-# repository.url is injected before pack so older tags still work with provenance.
-# Prerelease versions (e.g. 1.0.0-rc.1) are published with --tag rc (npm requires a non-latest tag).
 on:
   release:
     types: [published]
   workflow_dispatch:
     inputs:
-      package:
-        description: Which package to publish (manual only)
+      tag:
+        description: "Tag to publish (e.g. data-v1.0.0 or app-v1.0.0)"
         required: true
-        type: choice
-        options:
-          - data
-          - api
-        default: data
+        type: string
+      force_test:
+        description: "Force Test+Build even if CI history exists for the tag SHA"
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  id-token: write
+  actions: read
+  checks: read
 
 concurrency:
-  group: publish-${{ github.workflow }}-${{ github.ref }}
+  group: publish-${{ github.event.release.tag_name || inputs.tag }}
   cancel-in-progress: false
 
 jobs:
   publish:
-    name: Publish to npm
+    name: Publish
     runs-on: ubuntu-latest
-    timeout-minutes: 15
-    permissions:
-      contents: read
-      id-token: write
     if: >
-      github.event_name == 'workflow_dispatch' ||
-      startsWith(github.event.release.tag_name, 'data-v') ||
-      startsWith(github.event.release.tag_name, 'app-v')
-
+      (github.event_name == 'workflow_dispatch') ||
+      (github.event_name == 'release' && (
+        startsWith(github.event.release.tag_name, 'data-v') ||
+        startsWith(github.event.release.tag_name, 'app-v')
+      ))
     steps:
+      - name: Resolve tag and package
+        id: meta
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            TAG="$INPUT_TAG"
+          else
+            TAG="$RELEASE_TAG"
+          fi
+          case "$TAG" in
+            data-v*)
+              PKG_DIR="packages/jp-local-gov-id-data"
+              ;;
+            app-v*)
+              PKG_DIR="packages/jp-local-gov-id"
+              ;;
+            *)
+              echo "Unsupported tag: $TAG (expected data-v* or app-v*)"
+              exit 1
+              ;;
+          esac
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "package_dir=$PKG_DIR" >> "$GITHUB_OUTPUT"
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.ref }}
+          ref: refs/tags/${{ steps.meta.outputs.tag }}
+          fetch-depth: 0
 
-      - name: Resolve publish target
-        id: target
+      - name: Require tag commit on release ancestry
         run: |
           set -euo pipefail
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            package='${{ inputs.package }}'
-          else
-            tag='${{ github.event.release.tag_name }}'
-            case "$tag" in
-              data-v*) package=data ;;
-              app-v*) package=api ;;
-              *)
-                echo "::error::Unsupported tag '${tag}'. Use data-v* or app-v*."
-                exit 1
-                ;;
-            esac
+          git fetch origin release:refs/remotes/origin/release
+          TAG_SHA="$(git rev-parse HEAD)"
+          if ! git merge-base --is-ancestor "$TAG_SHA" origin/release; then
+            echo "Tag commit $TAG_SHA is not an ancestor of origin/release."
+            echo "Create data-v* / app-v* tags from the release branch."
+            exit 1
           fi
-          echo "package=${package}" >> "$GITHUB_OUTPUT"
-          echo "Resolved publish target: ${package}"
+          echo "Tag commit is on release ancestry: $TAG_SHA"
 
-      - name: Banner
-        run: |
-          echo "=============================================="
-          echo "PUBLISH_WORKFLOW_ID=tag-prefix-route-v5"
-          echo "event=${{ github.event_name }}"
-          echo "ref=${GITHUB_REF}"
-          echo "sha=${GITHUB_SHA}"
-          echo "target=${{ steps.target.outputs.package }}"
-          git log -1 --oneline
-          echo "=============================================="
+      - name: Check CI success history for tag SHA
+        id: ci_history
+        uses: actions/github-script@v7
+        env:
+          FORCE_TEST: ${{ inputs.force_test || 'false' }}
+        with:
+          script: |
+            if (process.env.FORCE_TEST === 'true') {
+              core.setOutput('skip_verify', 'false');
+              core.info('force_test=true — will run Test+Build');
+              return;
+            }
+            const sha = context.sha;
+            const { data: runs } = await github.rest.actions.listWorkflowRunsForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              head_sha: sha,
+              status: 'completed',
+              per_page: 30,
+            });
+            const ok = (runs.workflow_runs || []).some(
+              (r) => r.name === 'CI' && r.conclusion === 'success'
+            );
+            core.setOutput('skip_verify', ok ? 'true' : 'false');
+            core.info(ok
+              ? `CI success found for ${sha} — skipping Test/Build`
+              : `No CI success for ${sha} — will run Test+Build`);
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 24
-          registry-url: https://registry.npmjs.org
-
-      - name: Upgrade npm for Trusted Publishing
-        run: npm install -g npm@latest
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+          cache: npm
 
       - name: Install dependencies
         run: npm ci
 
       - name: Test
+        if: steps.ci_history.outputs.skip_verify != 'true'
         run: npm test
 
       - name: Build
+        if: steps.ci_history.outputs.skip_verify != 'true'
         run: npm run build
 
-      - name: Publish @b4moss/jp-local-gov-id-data
-        if: ${{ steps.target.outputs.package == 'data' }}
+      - name: Pack
+        id: pack
+        working-directory: ${{ steps.meta.outputs.package_dir }}
         run: |
           set -euo pipefail
-          expected='https://github.com/b4moss/jp-local-gov-id'
-          pkg_dir='packages/jp-local-gov-id-data'
+          TARBALL="$(npm pack --json | jq -r '.[0].filename')"
+          echo "tarball=$TARBALL" >> "$GITHUB_OUTPUT"
+          echo "Packed: $TARBALL"
 
-          node <<'EOF'
-          const fs = require('fs');
-          const path = 'packages/jp-local-gov-id-data/package.json';
-          const pkg = JSON.parse(fs.readFileSync(path, 'utf8'));
-          pkg.repository = {
-            type: 'git',
-            url: 'https://github.com/b4moss/jp-local-gov-id',
-            directory: 'packages/jp-local-gov-id-data',
-          };
-          fs.writeFileSync(path, JSON.stringify(pkg, null, 2) + '\n');
-          console.log('injected', pkg.repository);
-          EOF
-
-          cd "$pkg_dir"
-          tgz=$(npm pack --pack-destination . | tail -n1 | tr -d '\r')
-          echo "packed=${tgz}"
-          tar -xOf "$tgz" package/package.json > /tmp/packed-package.json
-          url=$(node -p "require('/tmp/packed-package.json').repository?.url ?? ''")
-          echo "packed repository.url=${url}"
-          if [ "$url" != "$expected" ]; then
-            echo "::error::Packed repository.url must be ${expected} (got '${url}')"
-            exit 1
-          fi
-          version=$(node -p "require('/tmp/packed-package.json').version")
-          publish_args=(--access public --provenance)
-          if [[ "$version" == *-* ]]; then
-            publish_args+=(--tag rc)
-            echo "prerelease detected (${version}); using --tag rc"
-          fi
-          npm publish "$tgz" "${publish_args[@]}"
-
-      - name: Publish @b4moss/jp-local-gov-id
-        if: ${{ steps.target.outputs.package == 'api' }}
+      - name: Inject repository.url into packed tarball
+        working-directory: ${{ steps.meta.outputs.package_dir }}
+        env:
+          TARBALL: ${{ steps.pack.outputs.tarball }}
+          REPO_URL: https://github.com/${{ github.repository }}
         run: |
           set -euo pipefail
-          expected='https://github.com/b4moss/jp-local-gov-id'
-          pkg_dir='packages/jp-local-gov-id'
+          TMPDIR="$(mktemp -d)"
+          tar -xzf "$TARBALL" -C "$TMPDIR"
+          node -e '
+            const fs = require("fs");
+            const path = require("path");
+            const pkgPath = path.join(process.argv[1], "package", "package.json");
+            const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8"));
+            const url = process.argv[2];
+            if (typeof pkg.repository === "string") {
+              pkg.repository = { type: "git", url };
+            } else {
+              pkg.repository = { ...(pkg.repository || {}), type: "git", url };
+            }
+            fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + "\n");
+          ' "$TMPDIR" "$REPO_URL"
+          tar -czf "$TARBALL" -C "$TMPDIR" package
+          rm -rf "$TMPDIR"
+          echo "Injected repository.url=$REPO_URL into $TARBALL"
 
-          node <<'EOF'
-          const fs = require('fs');
-          const path = 'packages/jp-local-gov-id/package.json';
-          const pkg = JSON.parse(fs.readFileSync(path, 'utf8'));
-          pkg.repository = {
-            type: 'git',
-            url: 'https://github.com/b4moss/jp-local-gov-id',
-            directory: 'packages/jp-local-gov-id',
-          };
-          fs.writeFileSync(path, JSON.stringify(pkg, null, 2) + '\n');
-          console.log('injected', pkg.repository);
-          EOF
-
-          cd "$pkg_dir"
-          tgz=$(npm pack --pack-destination . | tail -n1 | tr -d '\r')
-          echo "packed=${tgz}"
-          tar -xOf "$tgz" package/package.json > /tmp/packed-package.json
-          url=$(node -p "require('/tmp/packed-package.json').repository?.url ?? ''")
-          echo "packed repository.url=${url}"
-          if [ "$url" != "$expected" ]; then
-            echo "::error::Packed repository.url must be ${expected} (got '${url}')"
-            exit 1
-          fi
-          version=$(node -p "require('/tmp/packed-package.json').version")
-          publish_args=(--access public --provenance)
-          if [[ "$version" == *-* ]]; then
-            publish_args+=(--tag rc)
-            echo "prerelease detected (${version}); using --tag rc"
-          fi
-          npm publish "$tgz" "${publish_args[@]}"
+      - name: Publish to npm (provenance)
+        working-directory: ${{ steps.meta.outputs.package_dir }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          TARBALL: ${{ steps.pack.outputs.tarball }}
+        run: npm publish --access public --provenance "$TARBALL"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -119,7 +119,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
           cache: npm
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -74,6 +74,7 @@ jobs:
           fetch-depth: 0
 
       - name: Require tag commit on release ancestry
+        id: ancestry
         run: |
           set -euo pipefail
           git fetch origin release:refs/remotes/origin/release
@@ -84,12 +85,14 @@ jobs:
             exit 1
           fi
           echo "Tag commit is on release ancestry: $TAG_SHA"
+          echo "sha=$TAG_SHA" >> "$GITHUB_OUTPUT"
 
       - name: Check CI success history for tag SHA
         id: ci_history
         uses: actions/github-script@v7
         env:
           FORCE_TEST: ${{ inputs.force_test || 'false' }}
+          TAG_SHA: ${{ steps.ancestry.outputs.sha }}
         with:
           script: |
             if (process.env.FORCE_TEST === 'true') {
@@ -97,7 +100,7 @@ jobs:
               core.info('force_test=true — will run Test+Build');
               return;
             }
-            const sha = context.sha;
+            const sha = process.env.TAG_SHA;
             const { data: runs } = await github.rest.actions.listWorkflowRunsForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/release-on-tag.yml
+++ b/.github/workflows/release-on-tag.yml
@@ -1,36 +1,37 @@
+# Create a GitHub Release when a data-v* or app-v* tag is pushed.
+# Operational rule: create these tags from the `release` branch so Publish
+# (publish.yml) can verify ancestry and reuse CI success for the tag SHA.
+# site-v* tags are handled by deploy-docs.yml, not this workflow.
 name: Release on tag
 
 on:
   push:
     tags:
-      - "**"
+      - "data-v*"
+      - "app-v*"
 
 permissions:
   contents: write
 
 jobs:
   release:
+    name: Create GitHub Release
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-      - name: Create GitHub Release if missing
+      - name: Create release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
         run: |
           set -euo pipefail
-          TAG="${GITHUB_REF_NAME}"
-          if gh release view "$TAG" >/dev/null 2>&1; then
-            echo "Release already exists: $TAG"
-            exit 0
-          fi
-          PRE=()
-          if [[ "$TAG" =~ (alpha|beta|rc|rev|doc|docs) ]]; then
-            PRE+=(--prerelease)
-          fi
-          gh release create "$TAG" \
-            --title "$TAG" \
-            --generate-notes \
-            --verify-tag \
-            "${PRE[@]}"
+          TITLE="$TAG"
+          NOTES="Automated release for tag \`$TAG\`.
+
+          npm publish tags (\`data-v*\` / \`app-v*\`) should be created from the \`release\` branch.
+          Documentation site tags (\`site-v*\`) use the Deploy docs workflow instead."
+          gh release create "$TAG" --title "$TITLE" --notes "$NOTES"

--- a/README.md
+++ b/README.md
@@ -101,6 +101,15 @@ npm test
 npm run build
 ```
 
+Before opening or updating a PR to `develop` / `dev-*`, run local CI:
+
+```bash
+npm run ci:local            # preferred (nektos/act + Docker)
+npm run ci:local:fallback   # only if Docker is unavailable
+```
+
+See [docs/ci-cd.md](./docs/ci-cd.md) for triggers, skip rules, and publish.
+
 ## Versioning
 
 Follows [Semantic Versioning](https://semver.org/).

--- a/README_ja.md
+++ b/README_ja.md
@@ -101,6 +101,15 @@ npm test
 npm run build
 ```
 
+`develop` / `dev-*` 向け PR の作成・更新前に、ローカル CI を通してください。
+
+```bash
+npm run ci:local            # 推奨（nektos/act + Docker）
+npm run ci:local:fallback   # Docker が無いときのみ
+```
+
+発火条件・スキップ・publish は [docs/ci-cd.ja.md](./docs/ci-cd.ja.md) を参照。
+
 ## バージョン方針
 
 [Semantic Versioning](https://semver.org/) に従います。

--- a/docs/ci-cd.ja.md
+++ b/docs/ci-cd.ja.md
@@ -1,0 +1,65 @@
+# CI / CD
+
+GitHub Actions の発火条件、PR 前のローカル必須ゲート、npm publish と CI 履歴の関係をまとめます。
+
+## ローカルゲート（PR 前必須）
+
+`develop` / `dev-*` 向けの PR を作成・更新する前に、**`act` の成功を必須**とします（人間・Cloud Agent 共通）。
+
+```bash
+# 推奨（Docker + nektos/act が必要）
+npm run ci:local
+
+# 同等
+act pull_request -W .github/workflows/ci.yml
+```
+
+既定は [`.actrc`](../.actrc) です。`act` 実行時はゲートが API スキップせず Test/Build を必ず実行します（`ACT=true`）。Codecov は `ACT` 時にスキップされます。
+
+Docker が無い環境（一部の Cloud Agent など）では次の代替を使えます。ただし **可能な環境では act を正**とします。
+
+```bash
+npm run ci:local:fallback   # npm ci && npm test && npm run build
+```
+
+ゲート失敗のまま PR しないでください。
+
+### エージェント向け
+
+1. `npm run ci:local` を実行（Docker が無いときだけ `ci:local:fallback`）
+2. 非 0 なら修正して再実行。PR 作成ツールはまだ呼ばない
+3. 成功後に PR を作成・更新する
+
+## CI（`.github/workflows/ci.yml`）
+
+| 項目 | ルール |
+|------|--------|
+| トリガ | base が `develop` または `dev-*` の `pull_request` |
+| 発火しない例 | 任意ブランチへの push、`main` / `release` などへの PR |
+| 重いジョブのスキップ | 同一 head SHA に成功済みの `CI` ワークフローがある |
+| docs のみ | `docs/**`・`site/content/**`・`*.md` 等のみ → GitHub 上は Test/Build スキップ。ローカル act は原則フル実行 |
+| 並行 | `Gate` の後に `Test` と `Build` を並行 |
+| required check 名 | 集約ジョブ **`Test & Build`**（branch protection 互換） |
+
+対象外（従来どおり）: `deploy-docs.yml`（`site-v*`）、`scorecard.yml`。
+
+## CD — npm publish（`.github/workflows/publish.yml`）
+
+| 項目 | ルール |
+|------|--------|
+| トリガ | `data-v*` / `app-v*` の GitHub Release **published**、またはタグ指定の `workflow_dispatch` |
+| 祖先チェック | タグのコミットが `origin/release` の祖先であること |
+| 検証スキップ | その SHA に CI success があれば Test/Build 省略。pack + provenance publish は常に実行 |
+| 履歴なし | Test + Build のあと publish |
+| dispatch | `force_test` で常に Test+Build 可能 |
+
+`data-v*` / `app-v*` タグは **`release` ブランチから**打つ。`release-on-tag.yml` はこれらのタグのみ自動 Release 作成（`site-v*` は docs 側）。
+
+## 流れ
+
+```text
+ローカル変更 → npm run ci:local（必須）
+            → develop / dev-* へ PR
+            → CI Gate → Test ‖ Build → "Test & Build"
+release 上のタグ → Release → Publish（CI 再利用 or 再検証）→ npm
+```

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -1,0 +1,65 @@
+# CI / CD
+
+This document describes when GitHub Actions runs, the mandatory local pre-PR gate, and how npm publish reuses CI history.
+
+## Local gate (required before PR)
+
+Before opening or updating a pull request targeting `develop` or `dev-*`, **`act` must succeed** (developers and Cloud Agents).
+
+```bash
+# Preferred (requires Docker + nektos/act)
+npm run ci:local
+
+# Equivalent
+act pull_request -W .github/workflows/ci.yml
+```
+
+Defaults live in [`.actrc`](../.actrc). Under `act`, the CI gate always runs Test/Build (`ACT=true` bypasses the GitHub API skip). Codecov is skipped when `ACT` is set.
+
+If Docker is unavailable (some Cloud Agent / constrained environments), use the fallback and treat it as a temporary substitute — **act remains the source of truth** wherever Docker works:
+
+```bash
+npm run ci:local:fallback   # npm ci && npm test && npm run build
+```
+
+Do not open or update a PR while this gate is failing.
+
+### Agents
+
+1. Run `npm run ci:local` (or `ci:local:fallback` only when Docker is absent).
+2. If non-zero, fix and re-run; do not call the PR creation tool yet.
+3. Only then open/update the PR.
+
+## CI (`.github/workflows/ci.yml`)
+
+| Item | Rule |
+|------|------|
+| Trigger | `pull_request` whose **base** is `develop` or `dev-*` |
+| Not triggered | Push to arbitrary branches; PRs into `main` / `release` / other bases |
+| Skip heavy jobs | Same head SHA already has a successful `CI` workflow run |
+| Docs-only | Changes limited to `docs/**`, `site/content/**`, `*.md` (and similar) → skip Test/Build on GitHub; local act still runs full jobs by default |
+| Parallelism | `Test` and `Build` jobs run in parallel after `Gate` |
+| Required check name | Aggregate job **`Test & Build`** (stable for branch protection) |
+
+Out of scope (unchanged): `deploy-docs.yml` (`site-v*`), `scorecard.yml`.
+
+## CD — npm publish (`.github/workflows/publish.yml`)
+
+| Item | Rule |
+|------|------|
+| Trigger | GitHub Release **published** for `data-v*` / `app-v*`, or `workflow_dispatch` with a tag |
+| Ancestry | Tag commit must be an ancestor of `origin/release` (`git merge-base --is-ancestor`) |
+| Verify skip | If that SHA already has CI success → skip Test/Build; always pack + provenance publish |
+| No CI history | Run Test + Build, then publish |
+| Dispatch | Optional `force_test` to always run Test+Build |
+
+Create `data-v*` / `app-v*` tags from the **`release`** branch. `release-on-tag.yml` auto-creates the GitHub Release for those tag patterns only (`site-v*` stays on the docs workflow).
+
+## Quick reference
+
+```text
+local change → npm run ci:local (must pass)
+            → open PR to develop / dev-*
+            → CI Gate → Test ‖ Build → "Test & Build"
+tag on release → Release → Publish (reuse CI or re-verify) → npm
+```

--- a/docs/main.md
+++ b/docs/main.md
@@ -372,6 +372,7 @@ jp-local-gov-id/
 - リポジトリは npm workspaces のモノレポとする
 - API パッケージ（`packages/jp-local-gov-id`）の開発は Vite + TypeScript（ライブラリモード）
 - パーススクリプト（`scripts/`）は独自の `package.json` を持ち、Node.js で実行する
+- CI/CD（PR 前の `act` 必須・発火条件・publish）は [ci-cd.ja.md](./ci-cd.ja.md) / [ci-cd.md](./ci-cd.md) を参照
 
 ### パッケージサイズ・取得
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "test": "npm run test -w @b4moss/jp-local-gov-id",
     "generate": "npm run generate -w jp-local-gov-id-scripts",
     "check-publish": "node scripts/check-publish.mjs",
-    "publish:dry-run": "node scripts/publish-package.mjs packages/jp-local-gov-id-data --dry-run && node scripts/publish-package.mjs packages/jp-local-gov-id --dry-run"
+    "publish:dry-run": "node scripts/publish-package.mjs packages/jp-local-gov-id-data --dry-run && node scripts/publish-package.mjs packages/jp-local-gov-id --dry-run",
+    "ci:local": "act pull_request -W .github/workflows/ci.yml",
+    "ci:local:fallback": "npm ci && npm test && npm run build"
   },
   "license": "MIT",
   "engines": {

--- a/site/content/en/contribute.md
+++ b/site/content/en/contribute.md
@@ -27,6 +27,17 @@ npm test
 npm run build
 ```
 
+### Required gate before PR
+
+Before opening or updating a PR targeting `develop` / `dev-*`, run local CI (do not open a PR while it fails):
+
+```bash
+npm run ci:local            # preferred (nektos/act + Docker)
+npm run ci:local:fallback   # only if Docker is unavailable
+```
+
+See [docs/ci-cd.md](https://github.com/b4moss/jp-local-gov-id/blob/main/docs/ci-cd.md) for triggers, CD, and agent instructions.
+
 Regenerate data (Ministry of Internal Affairs Excel → CSV in the repo → `.bin` for npm):
 
 ```bash

--- a/site/content/ja/contribute.md
+++ b/site/content/ja/contribute.md
@@ -27,6 +27,17 @@ npm test
 npm run build
 ```
 
+### PR 前の必須ゲート
+
+`develop` / `dev-*` 向けの PR を出す前に、ローカルで CI 相当を通してください（失敗したまま PR しない）。
+
+```bash
+npm run ci:local            # 推奨（nektos/act + Docker）
+npm run ci:local:fallback   # Docker が無い環境のみ
+```
+
+発火条件・CD・エージェント向け手順はリポジトリの [docs/ci-cd.ja.md](https://github.com/b4moss/jp-local-gov-id/blob/main/docs/ci-cd.ja.md) を参照してください。
+
 データの再生成（総務省の Excel → CSV（リポジトリのみ）→ `.bin`（npm 公開））:
 
 ```bash


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **CI** (`ci.yml`): runs only on `pull_request` to `develop` / `dev-*`; gate skips heavy jobs when the head SHA already has CI success or the diff is docs-only; `Test` and `Build` run in parallel; aggregate job keeps the required check name **`Test & Build`**.
- **Local gate**: `.actrc` + `npm run ci:local` (act). Docker-less fallback: `npm run ci:local:fallback`. Documented as mandatory before PR (humans + agents).
- **CD** (`publish.yml`): tag commit must be an ancestor of `origin/release`; skip Test/Build when that SHA has CI success; always pack + provenance publish; npm cache; Node 24.
- **`release-on-tag.yml`**: only `data-v*` / `app-v*`; comments require tagging from `release`.
- **Docs**: `docs/ci-cd.md` / `docs/ci-cd.ja.md`, README, contribute pages, `docs/main.md`.

## Branch protection / required checks

Required check name remains **`Test & Build`** (aggregate job). No branch-protection rename should be needed.

## Verification

- This environment has **no Docker**, so `act` could not run; **`npm run ci:local:fallback`** passed (`npm ci` + test + build).
- Where Docker is available, prefer `npm run ci:local` before merge.

## Out of scope (unchanged)

`deploy-docs.yml`, `scorecard.yml`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a04bfd-ea6d-72f8-ae17-5235c0d55140?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a04bfd-ea6d-72f8-ae17-5235c0d55140&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

