### PR TITLE
feat(api): CJS + CDN IIFE/minify 配布 (#65 #67) (#89)

### DIFF
--- a/packages/jp-local-gov-id/README.md
+++ b/packages/jp-local-gov-id/README.md
@@ -12,6 +12,8 @@ npm install @b4moss/jp-local-gov-id @b4moss/jp-local-gov-id-data
 npm install @b4moss/jp-local-gov-id
 ```
 
+ESM and CommonJS are both published (`import` / `require`). For plain HTML / CDN, prefer the minified IIFE (`dist/jp-local-gov-id.iife.min.js`) with a **matching** versioned data `index.json` URL — see the [installation docs](https://jplocalgov.oss.b4m.jp/en/installation).
+
 ## Usage
 
 `createLocalGovClient` is async. Either `data` or `url` (a **versioned URL** to **index.json**) is required.

--- a/packages/jp-local-gov-id/README_ja.md
+++ b/packages/jp-local-gov-id/README_ja.md
@@ -12,6 +12,8 @@ npm install @b4moss/jp-local-gov-id @b4moss/jp-local-gov-id-data
 npm install @b4moss/jp-local-gov-id
 ```
 
+ESM と CommonJS の両方を配布しています（`import` / `require`）。HTML / CDN では minify 済み IIFE（`dist/jp-local-gov-id.iife.min.js`）と、**同じ版**のデータ `index.json` URL をセットで使うのがおすすめです。詳細は [インストール](https://jplocalgov.oss.b4m.jp/ja/installation) を参照してください。
+
 ## 使い方
 
 `createLocalGovClient` は async です。`data` または `url`（**index.json** の版付き URL）のいずれかが必須です。

--- a/packages/jp-local-gov-id/package.json
+++ b/packages/jp-local-gov-id/package.json
@@ -3,12 +3,16 @@
   "version": "1.0.0-rc.10",
   "description": "全国地方公共団体コードヘルパ — 日本の全国地方公共団体コードを扱う npm パッケージ",
   "type": "module",
-  "main": "./dist/jp-local-gov-id.js",
+  "main": "./dist/jp-local-gov-id.cjs",
+  "module": "./dist/jp-local-gov-id.js",
   "types": "./dist/index.d.ts",
+  "unpkg": "./dist/jp-local-gov-id.iife.min.js",
+  "jsdelivr": "./dist/jp-local-gov-id.iife.min.js",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/jp-local-gov-id.js"
+      "import": "./dist/jp-local-gov-id.js",
+      "require": "./dist/jp-local-gov-id.cjs"
     }
   },
   "files": [
@@ -19,7 +23,7 @@
   ],
   "scripts": {
     "dev": "vite build --watch",
-    "build": "vite build",
+    "build": "node ./scripts/build.mjs",
     "test": "vitest run --coverage"
   },
   "keywords": [

--- a/packages/jp-local-gov-id/scripts/build.mjs
+++ b/packages/jp-local-gov-id/scripts/build.mjs
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+/**
+ * Multi-format library build for @b4moss/jp-local-gov-id (#65 / #67).
+ * 1) ESM + CJS (+ d.ts) via vite.config.ts
+ * 2) IIFE (CDN) via vite.cdn.config.ts
+ * 3) IIFE minify (CDN) via vite.cdn.config.ts --mode minify
+ */
+import { build } from "vite";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const pkg = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+await build({
+  configFile: join(pkg, "vite.config.ts"),
+  root: pkg,
+});
+await build({
+  configFile: join(pkg, "vite.cdn.config.ts"),
+  root: pkg,
+});
+await build({
+  configFile: join(pkg, "vite.cdn.config.ts"),
+  root: pkg,
+  mode: "minify",
+});

--- a/packages/jp-local-gov-id/vite.cdn.config.ts
+++ b/packages/jp-local-gov-id/vite.cdn.config.ts
@@ -1,0 +1,37 @@
+import { resolve } from "node:path";
+import { defineConfig } from "vite";
+
+const entry = resolve(import.meta.dirname, "src/index.ts");
+const external = ["node:zlib", "brotli-wasm"];
+
+/**
+ * CDN IIFE builds (#65 / #67). Invoked twice from scripts/build.mjs
+ * (unminified + minified). Does not emit .d.ts (npm build owns that).
+ */
+export default defineConfig(({ mode }) => {
+  const minify = mode === "minify";
+  return {
+    build: {
+      emptyOutDir: false,
+      lib: {
+        entry,
+        name: "JpLocalGovId",
+        formats: ["iife"],
+        fileName: () =>
+          minify ? "jp-local-gov-id.iife.min.js" : "jp-local-gov-id.iife.js",
+      },
+      rollupOptions: {
+        external,
+        output: {
+          // Dynamic import("node:zlib") / import("brotli-wasm") stay as
+          // runtime imports when those paths run; browsers use DecompressionStream.
+          globals: {
+            "node:zlib": "zlib",
+            "brotli-wasm": "BrotliWasm",
+          },
+        },
+      },
+      minify: minify ? "esbuild" : false,
+    },
+  };
+});

--- a/packages/jp-local-gov-id/vite.config.ts
+++ b/packages/jp-local-gov-id/vite.config.ts
@@ -2,6 +2,17 @@ import { resolve } from "node:path";
 import dts from "vite-plugin-dts";
 import { defineConfig } from "vitest/config";
 
+const entry = resolve(import.meta.dirname, "src/index.ts");
+const external = ["node:zlib", "brotli-wasm"];
+
+/**
+ * Library builds (#65 / #67):
+ * - npm: ESM + CJS (readable; Node externals stay external)
+ * - CDN: IIFE + IIFE minify (browser `<script>`; same externals — prefer
+ *   DecompressionStream("brotli") in modern browsers)
+ *
+ * Vitest ignores `build` and uses `test` from this config.
+ */
 export default defineConfig({
   plugins: [
     dts({
@@ -11,15 +22,19 @@ export default defineConfig({
     }),
   ],
   build: {
+    // CDN builds append into dist without wiping ESM/CJS (see scripts/build.mjs).
+    emptyOutDir: true,
     lib: {
-      entry: resolve(import.meta.dirname, "src/index.ts"),
+      entry,
       name: "JpLocalGovId",
-      formats: ["es"],
-      fileName: "jp-local-gov-id",
+      formats: ["es", "cjs"],
+      fileName: (format) =>
+        format === "es" ? "jp-local-gov-id.js" : "jp-local-gov-id.cjs",
     },
     rollupOptions: {
-      external: ["node:zlib", "brotli-wasm"],
+      external,
     },
+    minify: false,
   },
   test: {
     include: ["src/**/*.test.ts"],

--- a/site/content/en/installation.md
+++ b/site/content/en/installation.md
@@ -17,13 +17,51 @@ npm install @b4moss/jp-local-gov-id
 
 Use `data` when you install the data package; use `url` when you only install the API. See [Usage](/en/usage).
 
+Both ESM (`import`) and CommonJS (`require`) are published.
+
+```js
+// ESM
+import { createLocalGovClient } from "@b4moss/jp-local-gov-id";
+
+// CommonJS
+const { createLocalGovClient } = require("@b4moss/jp-local-gov-id");
+```
+
 ## Without a package manager (HTML)
 
+You can load the library directly in the browser without npm / Vite / webpack.
+
+In the browser, prefer `url` + `index.json` / `.bin.br` over bundling `dataset.js` (Node-oriented). The client Brotli-decompresses then decodes (via modern `DecompressionStream("brotli")`).
+
+On a CDN, use the **same version** for the JS API and the data package’s versioned `index.json`.
+
+### From a CDN (recommended: minified IIFE)
+
+For plain HTML, the minified IIFE build is simplest. APIs are exposed on the global `JpLocalGovId`.
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+  <body>
+    <script src="https://cdn.jsdelivr.net/npm/@b4moss/jp-local-gov-id@1.0.0-rc.10/dist/jp-local-gov-id.iife.min.js"></script>
+    <script>
+      const { createLocalGovClient } = JpLocalGovId;
+
+      createLocalGovClient({
+        url: "https://cdn.jsdelivr.net/npm/@b4moss/jp-local-gov-id-data@1.0.0-rc.10/index.json",
+      }).then(async (client) => {
+        console.log(await client.getByCode("131016"));
+      });
+    </script>
+  </body>
+</html>
+```
+
+The non-minified IIFE is `dist/jp-local-gov-id.iife.js`.
+
+### From a CDN (ES module)
+
 `dist/jp-local-gov-id.js` is an **ES module** — load it with `<script type="module">`.
-
-In the browser, prefer `url` + `index.json` / `.bin.br` over bundling `dataset.js` (Node-oriented). The client Brotli-decompresses then decodes.
-
-### From a CDN
 
 ```html
 <!DOCTYPE html>
@@ -48,7 +86,7 @@ In the browser, prefer `url` + `index.json` / `.bin.br` over bundling `dataset.j
 your-site/
   index.html
   vendor/
-    jp-local-gov-id.js
+    jp-local-gov-id.iife.min.js
   jp-local-gov-id-data/
     index.json
     prefectures.bin.br
@@ -69,14 +107,15 @@ your-site/
 <!DOCTYPE html>
 <html lang="en">
   <body>
-    <script type="module">
-      import { createLocalGovClient } from "./vendor/jp-local-gov-id.js";
+    <script src="./vendor/jp-local-gov-id.iife.min.js"></script>
+    <script>
+      const { createLocalGovClient } = JpLocalGovId;
 
-      const client = await createLocalGovClient({
+      createLocalGovClient({
         url: "./jp-local-gov-id-data/index.json",
+      }).then(async (client) => {
+        console.log(await client.getByCode("131016"));
       });
-
-      console.log(await client.getByCode("131016"));
     </script>
   </body>
 </html>

--- a/site/content/ja/installation.md
+++ b/site/content/ja/installation.md
@@ -17,15 +17,51 @@ npm install @b4moss/jp-local-gov-id
 
 データ付きで入れる場合は `data` オプション、API のみの場合は `url` オプションで初期化します。詳しくは [使い方](/ja/usage) を参照してください。
 
+ESM（`import`）と CommonJS（`require`）の両方を配布しています。
+
+```js
+// ESM
+import { createLocalGovClient } from "@b4moss/jp-local-gov-id";
+
+// CommonJS
+const { createLocalGovClient } = require("@b4moss/jp-local-gov-id");
+```
+
 ## パッケージマネージャーを使わない場合（HTML）
 
 npm / Vite / webpack を使わず、ブラウザから直接読み込むこともできます。
 
-配布されている `dist/jp-local-gov-id.js` は **ES module** です。そのため `<script type="module">` で読み込みます。
+ブラウザでは `dataset.js`（Node 向け）をバンドルせず、`url` で `index.json` + `.bin.br` を読むのがおすすめです。クライアントが Brotli を展開してからデコードします（モダンブラウザの `DecompressionStream("brotli")` を利用）。
 
-ブラウザでは `dataset.js`（Node 向け）をバンドルせず、`url` で `index.json` + `.bin.br` を読むのがおすすめです。クライアントが Brotli を展開してからデコードします。
+CDN では **JS（API）とデータ（版付き `index.json`）を同じ版でセット**にして使ってください。
 
-### CDN から読む
+### CDN から読む（推奨: minify IIFE）
+
+バンドラーなしの HTML では、CDN 向けの minify 済み IIFE が手軽です。グローバル `JpLocalGovId` に API が載ります。
+
+```html
+<!DOCTYPE html>
+<html lang="ja">
+  <body>
+    <script src="https://cdn.jsdelivr.net/npm/@b4moss/jp-local-gov-id@1.0.0-rc.10/dist/jp-local-gov-id.iife.min.js"></script>
+    <script>
+      const { createLocalGovClient } = JpLocalGovId;
+
+      createLocalGovClient({
+        url: "https://cdn.jsdelivr.net/npm/@b4moss/jp-local-gov-id-data@1.0.0-rc.10/index.json",
+      }).then(async (client) => {
+        console.log(await client.getByCode("131016"));
+      });
+    </script>
+  </body>
+</html>
+```
+
+デバッグ用の非 minify IIFE は `dist/jp-local-gov-id.iife.js` です。
+
+### CDN から読む（ES module）
+
+`dist/jp-local-gov-id.js` は **ES module** です。`<script type="module">` で読み込みます。
 
 ```html
 <!DOCTYPE html>
@@ -46,7 +82,7 @@ npm / Vite / webpack を使わず、ブラウザから直接読み込むこと�
 
 ### dist をダウンロードして置く
 
-1. API の `dist/jp-local-gov-id.js` を取得する
+1. API の `dist/jp-local-gov-id.iife.min.js`（または ESM の `jp-local-gov-id.js`）を取得する
 2. データは次を同じ階層で置く（`dataset.js` は不要）
 3. HTML から相対パスで読む
 
@@ -54,7 +90,7 @@ npm / Vite / webpack を使わず、ブラウザから直接読み込むこと�
 your-site/
   index.html
   vendor/
-    jp-local-gov-id.js
+    jp-local-gov-id.iife.min.js
   jp-local-gov-id-data/
     index.json
     prefectures.bin.br
@@ -75,14 +111,15 @@ your-site/
 <!DOCTYPE html>
 <html lang="ja">
   <body>
-    <script type="module">
-      import { createLocalGovClient } from "./vendor/jp-local-gov-id.js";
+    <script src="./vendor/jp-local-gov-id.iife.min.js"></script>
+    <script>
+      const { createLocalGovClient } = JpLocalGovId;
 
-      const client = await createLocalGovClient({
+      createLocalGovClient({
         url: "./jp-local-gov-id-data/index.json",
+      }).then(async (client) => {
+        console.log(await client.getByCode("131016"));
       });
-
-      console.log(await client.getByCode("131016"));
     </script>
   </body>
 </html>


### PR DESCRIPTION
* feat(api): add CJS and CDN IIFE/minify builds (#65 #67)

Ship CommonJS for npm require(), plus browser IIFE and minified IIFE for CDN/<script> use. Document matching versioned JS + data index URLs.



* fix(build): invoke vite without shell in multi-format build



* fix(build): use vite build API instead of resolving bin path

require.resolve('vite/bin/vite.js') fails on Node 24 because the subpath is not in vite's package 