### PR TITLE
feat(site): sync doc-site template v0.9.0 (#95)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19605,7 +19605,8 @@
         "semver": "^7.8.5",
         "sucrase": "^3.35.0",
         "vue": "^3.5.35",
-        "vue-router": "^5.1.0"
+        "vue-router": "^5.1.0",
+        "yaml": "^2.9.0"
       },
       "devDependencies": {
         "@types/semver": "^7.8.0"

--- a/site/.gitignore
+++ b/site/.gitignore
@@ -28,3 +28,6 @@ logs
 .env
 .env.*
 !.env.example
+
+# Local site meta (copy from site.meta.yaml.example)
+site.meta.yaml

--- a/site/app/app.vue
+++ b/site/app/app.vue
@@ -9,6 +9,15 @@ useHead({
       : `${brand} by Bicycle for Mind LLC`;
   },
 });
+
+/** html lang/dir plus canonical and hreflang alternates for every route. */
+const localeHead = useLocaleHead({ dir: true, lang: true, seo: true });
+
+useHead(() => ({
+  htmlAttrs: localeHead.value.htmlAttrs,
+  link: localeHead.value.link,
+  meta: localeHead.value.meta,
+}));
 </script>
 
 <template>

--- a/site/app/assets/css/main.css
+++ b/site/app/assets/css/main.css
@@ -17,6 +17,7 @@
   --max-width-wide: 76rem;
   --header-height: 3.5rem;
   --sidebar-width: 15.5rem;
+  accent-color: var(--color-accent);
 }
 
 .dark {
@@ -40,8 +41,13 @@
   box-sizing: border-box;
 }
 
+/* Follow the active theme so native checkbox/radio match light vs dark. */
 html {
-  color-scheme: light dark;
+  color-scheme: light;
+}
+
+html.dark {
+  color-scheme: dark;
 }
 
 body {
@@ -77,9 +83,11 @@ code {
   border-radius: 0.25rem;
 }
 
+/* Intentionally dark in both light and dark UI themes.
+   Paired with Shiki `github-dark-high-contrast` (not github-light). */
 pre {
-  background: #0d1117;
-  color: #e6edf3;
+  background: #0a0c10;
+  color: #f0f3f6;
   padding: 1rem 1.15rem;
   border-radius: 0.5rem;
   overflow-x: auto;
@@ -91,6 +99,16 @@ pre code {
   background: transparent;
   padding: 0;
   color: inherit;
+}
+
+/* Light-mode native controls (task lists, future forms). */
+input[type="checkbox"],
+input[type="radio"] {
+  width: 1rem;
+  height: 1rem;
+  margin: 0 0.35em 0 0;
+  vertical-align: middle;
+  accent-color: var(--color-accent);
 }
 
 .site-shell {

--- a/site/app/components/DocsJsonLd.vue
+++ b/site/app/components/DocsJsonLd.vue
@@ -1,0 +1,35 @@
+<script lang="ts">
+import { defineComponent, toRef, type PropType } from "vue";
+import type { SchemaRole } from "~/composables/useJsonLd";
+import type { PageJsonLdInput } from "~/utils/jsonLdEntities";
+import type { FaqQa } from "~/utils/extractFaq";
+
+/**
+ * Head-only helper: JSON-LD is injected via useHead.
+ * Must render `null` (not an empty / comment-only template) so SSR and client
+ * agree on a single comment anchor — empty templates are stripped in production
+ * builds and cause hydration mismatches that wipe the page body.
+ */
+export default defineComponent({
+  name: "DocsJsonLd",
+  props: {
+    pageUrl: { type: String, required: true },
+    title: { type: String, required: true },
+    description: { type: String, required: false },
+    schemaRole: { type: String as PropType<SchemaRole>, required: false },
+    jsonLd: { type: Object as PropType<PageJsonLdInput>, required: false },
+    faqItems: { type: Array as PropType<FaqQa[]>, required: false },
+  },
+  setup(props) {
+    useJsonLd({
+      pageUrl: toRef(props, "pageUrl"),
+      title: toRef(props, "title"),
+      description: toRef(props, "description"),
+      schemaRole: toRef(props, "schemaRole"),
+      jsonLd: toRef(props, "jsonLd"),
+      faqItems: toRef(props, "faqItems"),
+    });
+    return () => null;
+  },
+});
+</script>

--- a/site/app/components/HeaderDropdown.vue
+++ b/site/app/components/HeaderDropdown.vue
@@ -42,8 +42,15 @@ watch(open, (isOpen) => {
     return;
   }
   if (isOpen) {
-    document.addEventListener("pointerdown", onDocumentPointerDown);
-    document.addEventListener("keydown", onKeydown);
+    // Defer outside-dismiss so the opening tap cannot immediately close on
+    // touch / Mobile Safari (pointerdown may still be in the same gesture).
+    queueMicrotask(() => {
+      if (!open.value) {
+        return;
+      }
+      document.addEventListener("pointerdown", onDocumentPointerDown);
+      document.addEventListener("keydown", onKeydown);
+    });
   } else {
     document.removeEventListener("pointerdown", onDocumentPointerDown);
     document.removeEventListener("keydown", onKeydown);

--- a/site/app/components/content/FaqItem.vue
+++ b/site/app/components/content/FaqItem.vue
@@ -1,0 +1,158 @@
+<script setup lang="ts">
+import {
+  faqListInjectionKey,
+  type FaqListContext,
+} from "~/utils/faqListContext";
+
+defineProps<{
+  question: string;
+}>();
+
+const id = useId();
+const faqList = inject<FaqListContext | null>(faqListInjectionKey, null);
+
+onMounted(() => {
+  faqList?.registerPanel(id);
+});
+
+onBeforeUnmount(() => {
+  faqList?.unregisterPanel(id);
+});
+
+const open = computed(() => faqList?.isOpen(id) ?? false);
+
+function onToggle() {
+  faqList?.toggle(id);
+}
+</script>
+
+<template>
+  <div class="faq-item" :data-open="open">
+    <h3 class="faq-item__question">
+      <button
+        class="faq-item__trigger"
+        type="button"
+        :aria-expanded="open"
+        :aria-controls="`${id}-panel`"
+        :id="`${id}-trigger`"
+        @click="onToggle"
+      >
+        <span>{{ question }}</span>
+        <span class="faq-item__chevron" aria-hidden="true" />
+      </button>
+    </h3>
+    <div
+      class="faq-item__panel"
+      :id="`${id}-panel`"
+      role="region"
+      :aria-labelledby="`${id}-trigger`"
+      :aria-hidden="!open"
+    >
+      <div class="faq-item__panel-inner">
+        <div class="faq-item__answer">
+          <slot />
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.faq-item {
+  border: 1px solid var(--color-border);
+  border-radius: 0.5rem;
+  background: var(--color-surface);
+}
+
+.faq-item__question {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.faq-item__trigger {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin: 0;
+  padding: 0.85rem 1rem;
+  border: none;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  font-weight: 600;
+  text-align: left;
+  cursor: pointer;
+}
+
+.faq-item__trigger:hover {
+  color: var(--color-accent);
+}
+
+.faq-item__chevron {
+  position: relative;
+  flex-shrink: 0;
+  width: 0.7rem;
+  height: 0.7rem;
+  border-right: 1.5px solid var(--color-muted);
+  border-bottom: 1.5px solid var(--color-muted);
+  transform: rotate(45deg);
+  transition: transform 0.28s ease, border-color 0.2s ease;
+}
+
+.faq-item__trigger:hover .faq-item__chevron {
+  border-color: var(--color-accent);
+}
+
+.faq-item[data-open="true"] .faq-item__chevron {
+  transform: rotate(225deg);
+}
+
+.faq-item__panel {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows 0.3s ease;
+}
+
+.faq-item[data-open="true"] .faq-item__panel {
+  grid-template-rows: 1fr;
+}
+
+.faq-item__panel-inner {
+  overflow: hidden;
+  min-height: 0;
+}
+
+.faq-item__answer {
+  padding: 0 1rem 1rem;
+  color: var(--color-ink);
+  opacity: 0;
+  transform: translateY(-0.2rem);
+  transition:
+    opacity 0.22s ease,
+    transform 0.28s ease;
+}
+
+.faq-item[data-open="true"] .faq-item__answer {
+  opacity: 1;
+  transform: none;
+}
+
+.faq-item__answer :deep(> *:first-child) {
+  margin-top: 0;
+}
+
+.faq-item__answer :deep(> *:last-child) {
+  margin-bottom: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .faq-item__panel,
+  .faq-item__answer,
+  .faq-item__chevron {
+    transition: none;
+  }
+}
+</style>

--- a/site/app/components/content/FaqList.vue
+++ b/site/app/components/content/FaqList.vue
@@ -1,0 +1,152 @@
+<script setup lang="ts">
+import {
+  faqListInjectionKey,
+  type FaqListContext,
+} from "~/utils/faqListContext";
+
+const { t } = useI18n();
+const panelIds = ref<string[]>([]);
+const openIds = ref<Set<string>>(new Set());
+
+const allOpen = computed(
+  () =>
+    panelIds.value.length > 0 &&
+    panelIds.value.every((id) => openIds.value.has(id)),
+);
+
+function registerPanel(id: string) {
+  if (!panelIds.value.includes(id)) {
+    panelIds.value = [...panelIds.value, id];
+  }
+}
+
+function unregisterPanel(id: string) {
+  panelIds.value = panelIds.value.filter((entry) => entry !== id);
+  if (openIds.value.has(id)) {
+    const next = new Set(openIds.value);
+    next.delete(id);
+    openIds.value = next;
+  }
+}
+
+function isOpen(id: string) {
+  return openIds.value.has(id);
+}
+
+function toggle(id: string) {
+  const next = new Set(openIds.value);
+  if (next.has(id)) {
+    next.delete(id);
+  } else {
+    next.add(id);
+  }
+  openIds.value = next;
+}
+
+function toggleAll() {
+  if (allOpen.value) {
+    openIds.value = new Set();
+  } else {
+    openIds.value = new Set(panelIds.value);
+  }
+}
+
+provide<FaqListContext>(faqListInjectionKey, {
+  registerPanel,
+  unregisterPanel,
+  isOpen,
+  toggle,
+});
+</script>
+
+<template>
+  <div class="faq-list">
+    <div class="faq-list__controls">
+      <button
+        class="faq-list__switch"
+        type="button"
+        role="switch"
+        :aria-checked="allOpen"
+        :aria-label="allOpen ? t('faq.collapseAll') : t('faq.expandAll')"
+        @click="toggleAll"
+      >
+        <span class="faq-list__switch-label">
+          {{ allOpen ? t("faq.collapseAll") : t("faq.expandAll") }}
+        </span>
+        <span class="faq-list__switch-track" aria-hidden="true">
+          <span class="faq-list__switch-thumb" />
+        </span>
+      </button>
+    </div>
+    <div class="faq-list__items">
+      <slot />
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.faq-list {
+  margin: 1.5rem 0;
+}
+
+.faq-list__controls {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 0.85rem;
+}
+
+.faq-list__switch {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.65rem;
+  margin: 0;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--color-muted);
+  font: inherit;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.faq-list__switch:hover {
+  color: var(--color-ink);
+}
+
+.faq-list__switch-track {
+  position: relative;
+  width: 2.5rem;
+  height: 1.35rem;
+  border-radius: 999px;
+  background: var(--color-border);
+  transition: background-color 0.22s ease;
+  flex-shrink: 0;
+}
+
+.faq-list__switch[aria-checked="true"] .faq-list__switch-track {
+  background: var(--color-accent);
+}
+
+.faq-list__switch-thumb {
+  position: absolute;
+  top: 0.15rem;
+  left: 0.15rem;
+  width: 1.05rem;
+  height: 1.05rem;
+  border-radius: 50%;
+  background: #fff;
+  box-shadow: 0 1px 2px rgb(0 0 0 / 0.12);
+  transition: transform 0.22s ease;
+}
+
+.faq-list__switch[aria-checked="true"] .faq-list__switch-thumb {
+  transform: translateX(1.15rem);
+}
+
+.faq-list__items {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+</style>

--- a/site/app/composables/useJsonLd.ts
+++ b/site/app/composables/useJsonLd.ts
@@ -1,0 +1,207 @@
+import type { FaqQa } from "~/utils/extractFaq";
+import type { SiteSoftwareMeta } from "~/utils/siteMeta";
+import {
+  buildJsonLdEntity,
+  buildOrganization,
+  buildWebPage,
+  resolveEntityInputs,
+  sanitizeExtraEntities,
+  type JsonLdObject,
+  type PageJsonLdInput,
+} from "~/utils/jsonLdEntities";
+
+export type SchemaRole = "TechArticle" | "HowTo" | "FAQPage";
+
+type UseJsonLdOptions = {
+  pageUrl: MaybeRefOrGetter<string>;
+  title: MaybeRefOrGetter<string>;
+  description?: MaybeRefOrGetter<string | undefined>;
+  schemaRole?: MaybeRefOrGetter<SchemaRole | undefined>;
+  jsonLd?: MaybeRefOrGetter<PageJsonLdInput | undefined>;
+  /** Q/A extracted from the page body; feeds FAQPage.mainEntity. */
+  faqItems?: MaybeRefOrGetter<FaqQa[] | undefined>;
+};
+
+/**
+ * Site-level WebSite node. Every WebPage points at it via isPartOf, so it has
+ * to exist in the graph for that reference to resolve.
+ */
+function webSiteEntity(
+  siteUrl: string,
+  config: ReturnType<typeof useRuntimeConfig>,
+  languages: string[],
+  organizationId?: string,
+) {
+  const entity: JsonLdObject = {
+    "@type": "WebSite",
+    "@id": `${siteUrl}/#website`,
+    url: `${siteUrl}/`,
+    name: config.public.siteName,
+    about: { "@id": `${siteUrl}/#software` },
+  };
+  if (organizationId) {
+    entity.publisher = { "@id": organizationId };
+  }
+  const description = config.public.description;
+  if (description) {
+    entity.description = description;
+  }
+  if (languages.length) {
+    entity.inLanguage = languages;
+  }
+  return entity;
+}
+
+/** Values are already resolved by normalizeSiteMeta(), so no fallbacks here. */
+function softwareEntity(siteUrl: string, config: ReturnType<typeof useRuntimeConfig>) {
+  const software = config.public.software as SiteSoftwareMeta;
+  const entity: JsonLdObject = {
+    "@type": "SoftwareSourceCode",
+    "@id": `${siteUrl}/#software`,
+    name: software.name,
+    codeRepository: software.codeRepository,
+  };
+  if (software.license) {
+    entity.license = software.license;
+  }
+  if (software.programmingLanguage?.length) {
+    entity.programmingLanguage = software.programmingLanguage;
+  }
+  return entity;
+}
+
+/** Q/A pairs collected from MDC, deduplicated by question text. */
+function faqQuestions(faqs: FaqQa[]): JsonLdObject[] {
+  const seen = new Set<string>();
+  const mainEntity: JsonLdObject[] = [];
+
+  for (const item of faqs) {
+    const question = item.question.trim();
+    const answer = item.answer.trim();
+    if (!question || !answer || seen.has(question)) {
+      continue;
+    }
+    seen.add(question);
+    mainEntity.push({
+      "@type": "Question",
+      name: question,
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: answer,
+      },
+    });
+  }
+
+  return mainEntity;
+}
+
+type LocaleEntry = { code: string; language?: string };
+
+export function useJsonLd(options: UseJsonLdOptions) {
+  const config = useRuntimeConfig();
+  const { locale, locales } = useI18n();
+
+  // Guards against a trailing slash arriving from an env override, which
+  // normalizeSiteMeta() does not see.
+  const siteUrl = String(config.public.siteUrl).replace(/\/$/, "");
+
+  /** BCP 47 tags (e.g. ja-JP) from the i18n locale config, code as fallback. */
+  const localeEntries = computed(() =>
+    (locales.value as Array<string | LocaleEntry>).map((entry) =>
+      typeof entry === "string" ? { code: entry } : entry,
+    ),
+  );
+
+  const languages = computed(() =>
+    localeEntries.value.map((entry) => entry.language || entry.code),
+  );
+
+  const inLanguage = computed(() => {
+    const current = localeEntries.value.find(
+      (entry) => entry.code === locale.value,
+    );
+    return current?.language || String(locale.value);
+  });
+
+  const graph = computed(() => {
+    const pageUrl = toValue(options.pageUrl);
+    const title = toValue(options.title);
+    const description = toValue(options.description);
+    const schemaRole = toValue(options.schemaRole);
+    const jsonLd = toValue(options.jsonLd);
+
+    const organization = buildOrganization(
+      config.public.organization as Record<string, unknown> | null,
+      siteUrl,
+      String(config.public.siteName),
+    );
+    const organizationId = organization
+      ? String(organization["@id"])
+      : undefined;
+
+    const webPage = buildWebPage(
+      {
+        pageUrl,
+        siteUrl,
+        title,
+        description,
+        inLanguage: inLanguage.value,
+        organizationId,
+      },
+      jsonLd?.webPage,
+    );
+
+    // Authored props may override the page @id, so resolve it before the role
+    // entities that reference it.
+    const resolvedPageUrl = String(webPage["@id"] || pageUrl);
+
+    const entities: JsonLdObject[] = [
+      webPage,
+      webSiteEntity(siteUrl, config, languages.value, organizationId),
+      softwareEntity(siteUrl, config),
+    ];
+
+    if (organization) {
+      entities.push(organization);
+    }
+
+    const entityContext = {
+      pageUrl: resolvedPageUrl,
+      siteUrl,
+      title,
+      description,
+      inLanguage: inLanguage.value,
+      faqMainEntity: faqQuestions(toValue(options.faqItems) || []),
+      organizationId,
+    };
+
+    for (const input of resolveEntityInputs(schemaRole, jsonLd)) {
+      const entity = buildJsonLdEntity(input, entityContext);
+      if (entity) {
+        entities.push(entity);
+      }
+    }
+
+    entities.push(
+      ...sanitizeExtraEntities(config.public.jsonLdExtra, "site.meta.yaml jsonLdExtra"),
+      ...sanitizeExtraEntities(jsonLd?.extra, "frontmatter jsonLd.extra"),
+    );
+
+    return {
+      "@context": "https://schema.org",
+      "@graph": entities,
+    };
+  });
+
+  useHead({
+    script: computed(() => [
+      {
+        key: "json-ld",
+        type: "application/ld+json",
+        children: JSON.stringify(graph.value),
+      },
+    ]),
+  });
+
+  return { graph };
+}

--- a/site/app/pages/[...slug].vue
+++ b/site/app/pages/[...slug].vue
@@ -1,22 +1,36 @@
 <script setup lang="ts">
 import { withLeadingSlash } from "ufo";
 import type { Collections } from "@nuxt/content";
+import type { SchemaRole } from "~/composables/useJsonLd";
+import { extractFaqFromBody, type FaqQa } from "~/utils/extractFaq";
+import {
+  includesEntityType,
+  type PageJsonLdInput,
+} from "~/utils/jsonLdEntities";
 
 const route = useRoute();
-const { locale, t } = useI18n();
+const { locale } = useI18n();
+const config = useRuntimeConfig();
 
+/**
+ * Content paths and useAsyncData keys must not depend on whether the static
+ * host served `/ja/faq` or `/ja/faq/`. Trailing-slash drift after hydration
+ * remounts the page with a new key, misses the payload cache, and throws 404 —
+ * which removes the FAQ DOM (and looks like "tap does nothing" on mobile).
+ */
 const slug = computed(() => {
   const raw = route.params.slug;
   if (!raw || (Array.isArray(raw) && raw.length === 0)) {
     return "/";
   }
   const joined = Array.isArray(raw) ? raw.join("/") : String(raw);
-  return withLeadingSlash(joined);
+  const withSlash = withLeadingSlash(joined);
+  return withSlash === "/" ? "/" : withSlash.replace(/\/+$/, "");
 });
 
 /** Ignore browser / tooling asset probes (e.g. manifest.webmanifest). */
 const isAssetPath = computed(() =>
-  /\.[a-z0-9]{2,8}$/i.test(slug.value.replace(/\/$/, "")),
+  /\.[a-z0-9]{2,8}$/i.test(slug.value),
 );
 
 if (isAssetPath.value) {
@@ -44,9 +58,45 @@ if (!page.value) {
   });
 }
 
+const pageTitle = computed(
+  () => page.value?.title || String(config.public.siteName || "Doc Site"),
+);
+
 useSeoMeta({
-  title: () => page.value?.title || t("brand"),
+  title: () => pageTitle.value,
   description: () => page.value?.description || undefined,
+});
+
+const siteUrl = computed(() =>
+  String(config.public.siteUrl || "https://example.com").replace(/\/$/, ""),
+);
+
+const pageUrl = computed(() => {
+  const path =
+    slug.value === "/" ? `/${locale.value}` : `/${locale.value}${slug.value}`;
+  return `${siteUrl.value}${path}`;
+});
+
+const schemaRole = computed(() => {
+  const role = (page.value as { schemaRole?: SchemaRole } | null)?.schemaRole;
+  return role;
+});
+
+const jsonLd = computed(
+  () => (page.value as { jsonLd?: PageJsonLdInput } | null)?.jsonLd,
+);
+
+const hasFaqEntity = computed(() =>
+  includesEntityType("FAQPage", schemaRole.value, jsonLd.value),
+);
+
+// Read from the content AST, not from rendered components, so the JSON-LD is
+// per-page and settled before render.
+const faqItems = computed<FaqQa[]>(() => {
+  if (!hasFaqEntity.value || !page.value?.body) {
+    return [];
+  }
+  return extractFaqFromBody(page.value.body);
 });
 </script>
 
@@ -55,6 +105,14 @@ useSeoMeta({
     <article class="prose">
       <ContentRenderer v-if="page" :value="page" />
     </article>
+    <DocsJsonLd
+      :page-url="pageUrl"
+      :title="pageTitle"
+      :description="page?.description || undefined"
+      :schema-role="schemaRole"
+      :json-ld="jsonLd"
+      :faq-items="faqItems"
+    />
     <DocsPager />
   </div>
 </template>

--- a/site/app/utils/buildSitemap.ts
+++ b/site/app/utils/buildSitemap.ts
@@ -1,0 +1,53 @@
+import { docsNavItems } from "~/composables/useDocsNav";
+
+export const sitemapLocales = ["ja", "en"] as const;
+
+export type SitemapLocale = (typeof sitemapLocales)[number];
+
+function escapeXml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&apos;");
+}
+
+/**
+ * Build a urlset sitemap from docsNav + locales (hreflang alternates included).
+ */
+export function buildSitemapXml(
+  siteUrl: string,
+  defaultLocale: SitemapLocale = "ja",
+): string {
+  const base = siteUrl.replace(/\/$/, "") || "https://example.com";
+
+  const urls = docsNavItems.map((item) => {
+    const path = item.path === "/" ? "" : item.path;
+    const locByLocale = Object.fromEntries(
+      sitemapLocales.map((locale) => [locale, `${base}/${locale}${path}`]),
+    ) as Record<SitemapLocale, string>;
+
+    const loc = locByLocale[defaultLocale];
+    const alternates = sitemapLocales
+      .map(
+        (locale) =>
+          `    <xhtml:link rel="alternate" hreflang="${locale}" href="${escapeXml(locByLocale[locale])}" />`,
+      )
+      .join("\n");
+    const xDefault = `    <xhtml:link rel="alternate" hreflang="x-default" href="${escapeXml(locByLocale[defaultLocale])}" />`;
+
+    return `  <url>
+    <loc>${escapeXml(loc)}</loc>
+${alternates}
+${xDefault}
+  </url>`;
+  });
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+        xmlns:xhtml="http://www.w3.org/1999/xhtml">
+${urls.join("\n")}
+</urlset>
+`;
+}

--- a/site/app/utils/extractFaq.ts
+++ b/site/app/utils/extractFaq.ts
@@ -1,0 +1,81 @@
+export type FaqQa = {
+  id: string;
+  question: string;
+  answer: string;
+};
+
+/** Flatten minimark / MDC node trees to plain text. */
+export function minimarkToText(input: unknown): string {
+  if (input == null || typeof input === "boolean") {
+    return "";
+  }
+  if (typeof input === "string" || typeof input === "number") {
+    return String(input);
+  }
+  if (Array.isArray(input)) {
+    // Minimark element: [tag, props, ...children]
+    if (typeof input[0] === "string") {
+      return input.slice(2).map(minimarkToText).join("");
+    }
+    return input.map(minimarkToText).join("");
+  }
+  if (typeof input === "object") {
+    const record = input as Record<string, unknown>;
+    if ("value" in record) {
+      return minimarkToText(record.value);
+    }
+    if ("children" in record) {
+      return minimarkToText(record.children);
+    }
+  }
+  return "";
+}
+
+/**
+ * Collect FAQ Q/A pairs from a Nuxt Content page body (minimark). This is the
+ * only source of FAQPage JSON-LD, so the output does not depend on component
+ * render order.
+ */
+export function extractFaqFromBody(body: unknown): FaqQa[] {
+  const results: FaqQa[] = [];
+  let index = 0;
+
+  function walk(node: unknown): void {
+    if (!Array.isArray(node)) {
+      if (node && typeof node === "object" && "value" in node) {
+        walk((node as { value: unknown }).value);
+      }
+      return;
+    }
+
+    if (typeof node[0] === "string") {
+      const tag = node[0];
+      const props = (node[1] || {}) as Record<string, unknown>;
+      const children = node.slice(2);
+
+      if (tag === "faq-item") {
+        const question = String(props.question || "").trim();
+        const answer = minimarkToText(children).replace(/\s+/g, " ").trim();
+        if (question && answer) {
+          results.push({
+            id: `body-faq-${index++}`,
+            question,
+            answer,
+          });
+        }
+      }
+
+      for (const child of children) {
+        walk(child);
+      }
+      return;
+    }
+
+    for (const child of node) {
+      walk(child);
+    }
+  }
+
+  walk(body);
+  return results;
+}

--- a/site/app/utils/faqListContext.ts
+++ b/site/app/utils/faqListContext.ts
@@ -1,0 +1,8 @@
+export const faqListInjectionKey = "doc-site-faq-list";
+
+export type FaqListContext = {
+  registerPanel: (id: string) => void;
+  unregisterPanel: (id: string) => void;
+  isOpen: (id: string) => boolean;
+  toggle: (id: string) => void;
+};

--- a/site/app/utils/jsonLdEntities.ts
+++ b/site/app/utils/jsonLdEntities.ts
@@ -1,0 +1,242 @@
+export type JsonLdObject = Record<string, unknown>;
+
+/** One entity declared in frontmatter: `type` plus schema.org properties. */
+export type JsonLdEntityInput = { type: string } & Record<string, unknown>;
+
+/** The `jsonLd` frontmatter block. */
+export type PageJsonLdInput = {
+  webPage?: Record<string, unknown>;
+  entities?: JsonLdEntityInput[];
+  /** Escape hatch: entities emitted verbatim, with no defaults applied. */
+  extra?: Record<string, unknown>[];
+};
+
+export type EntityBuildContext = {
+  /** Resolved WebPage @id; role entities hang off it via isPartOf. */
+  pageUrl: string;
+  siteUrl: string;
+  title: string;
+  description?: string;
+  inLanguage?: string;
+  faqMainEntity?: JsonLdObject[];
+  /** Set when site.meta.yaml declares an organization; used for publisher. */
+  organizationId?: string;
+};
+
+const KNOWN_FRAGMENTS: Record<string, string> = {
+  TechArticle: "article",
+  HowTo: "howto",
+  FAQPage: "faq",
+};
+
+function fragmentFor(type: string): string {
+  return (
+    KNOWN_FRAGMENTS[type] ||
+    type
+      .replace(/([a-z0-9])([A-Z])/g, "$1-$2")
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-|-$/g, "")
+  );
+}
+
+/**
+ * YAML parses unquoted dates into Date objects, which JSON.stringify would emit
+ * with a time component. Collapse midnight UTC back to a date-only literal so
+ * `datePublished: 2026-01-01` survives as written.
+ */
+export function normalizeJsonLdValue(value: unknown): unknown {
+  if (value instanceof Date) {
+    const iso = value.toISOString();
+    return iso.endsWith("T00:00:00.000Z") ? iso.slice(0, 10) : iso;
+  }
+  if (Array.isArray(value)) {
+    return value.map(normalizeJsonLdValue);
+  }
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as JsonLdObject).map(([key, entry]) => [
+        key,
+        normalizeJsonLdValue(entry),
+      ]),
+    );
+  }
+  return value;
+}
+
+function baseEntity(type: string, ctx: EntityBuildContext): JsonLdObject {
+  if (type === "TechArticle" || type === "HowTo") {
+    const entity: JsonLdObject = {
+      "@type": type,
+      "@id": `${ctx.pageUrl}#${fragmentFor(type)}`,
+      ...(type === "TechArticle"
+        ? { headline: ctx.title }
+        : { name: ctx.title }),
+      isPartOf: { "@id": ctx.pageUrl },
+      about: { "@id": `${ctx.siteUrl}/#software` },
+    };
+    if (ctx.organizationId) {
+      entity.publisher = { "@id": ctx.organizationId };
+    }
+    if (ctx.description) {
+      entity.description = ctx.description;
+    }
+    return entity;
+  }
+
+  if (type === "FAQPage") {
+    const entity: JsonLdObject = {
+      "@type": type,
+      "@id": `${ctx.pageUrl}#${fragmentFor(type)}`,
+      isPartOf: { "@id": ctx.pageUrl },
+    };
+    if (ctx.faqMainEntity?.length) {
+      entity.mainEntity = ctx.faqMainEntity;
+    }
+    return entity;
+  }
+
+  // Unknown type: only scaffold what is valid for every schema.org type. Which
+  // relationships apply (isPartOf, about, ...) depends on the type, so leave
+  // those to the author.
+  return {
+    "@type": type,
+    "@id": `${ctx.pageUrl}#${fragmentFor(type)}`,
+  };
+}
+
+/**
+ * Build one role entity: conventional defaults first, authored properties on
+ * top. Returns null when the entity would carry no meaning.
+ */
+export function buildJsonLdEntity(
+  input: JsonLdEntityInput,
+  ctx: EntityBuildContext,
+): JsonLdObject | null {
+  const type = String(input.type || "").trim();
+  if (!type) {
+    return null;
+  }
+
+  const { type: _type, ...authored } = input;
+  const entity: JsonLdObject = {
+    ...baseEntity(type, ctx),
+    ...(normalizeJsonLdValue(authored) as JsonLdObject),
+  };
+
+  if (type === "FAQPage" && !entity.mainEntity) {
+    return null;
+  }
+
+  return entity;
+}
+
+export function buildWebPage(
+  ctx: EntityBuildContext,
+  authored?: Record<string, unknown>,
+): JsonLdObject {
+  const entity: JsonLdObject = {
+    "@type": "WebPage",
+    "@id": ctx.pageUrl,
+    url: ctx.pageUrl,
+    name: ctx.title,
+    ...(ctx.inLanguage ? { inLanguage: ctx.inLanguage } : {}),
+    isPartOf: { "@id": `${ctx.siteUrl}/#website` },
+    about: { "@id": `${ctx.siteUrl}/#software` },
+  };
+  if (ctx.organizationId) {
+    entity.publisher = { "@id": ctx.organizationId };
+  }
+  if (ctx.description) {
+    entity.description = ctx.description;
+  }
+  return {
+    ...entity,
+    ...(normalizeJsonLdValue(authored || {}) as JsonLdObject),
+  };
+}
+
+/**
+ * Escape hatch entries are emitted as authored. Anything that is not a plain
+ * object is dropped with a warning rather than corrupting the graph.
+ */
+export function sanitizeExtraEntities(
+  entries: unknown,
+  source: string,
+): JsonLdObject[] {
+  if (!entries) {
+    return [];
+  }
+  if (!Array.isArray(entries)) {
+    console.warn(`[doc-site] ${source} must be an array; ignoring.`);
+    return [];
+  }
+
+  const result: JsonLdObject[] = [];
+  for (const entry of entries) {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+      console.warn(`[doc-site] ${source} entry is not an object; skipping.`);
+      continue;
+    }
+    result.push(normalizeJsonLdValue(entry) as JsonLdObject);
+  }
+  return result;
+}
+
+/**
+ * Site-wide Organization. Only emitted when site.meta.yaml declares one, so
+ * sites that have not filled it in keep their previous graph.
+ */
+export function buildOrganization(
+  authored: Record<string, unknown> | null | undefined,
+  siteUrl: string,
+  siteName: string,
+): JsonLdObject | null {
+  if (!authored || Object.keys(authored).length === 0) {
+    return null;
+  }
+  return {
+    "@type": "Organization",
+    "@id": `${siteUrl}/#organization`,
+    name: siteName,
+    url: `${siteUrl}/`,
+    ...(normalizeJsonLdValue(authored) as JsonLdObject),
+  };
+}
+
+function declaredEntities(jsonLd?: PageJsonLdInput): JsonLdEntityInput[] {
+  return (jsonLd?.entities || []).filter((entry) => entry && entry.type);
+}
+
+/**
+ * `jsonLd.entities` is the full form; `schemaRole` stays supported as the
+ * single-entity shorthand.
+ */
+export function resolveEntityInputs(
+  schemaRole: string | undefined,
+  jsonLd?: PageJsonLdInput,
+): JsonLdEntityInput[] {
+  const declared = declaredEntities(jsonLd);
+  if (declared.length) {
+    if (schemaRole) {
+      console.warn(
+        `[doc-site] schemaRole "${schemaRole}" is ignored because jsonLd.entities is set.`,
+      );
+    }
+    return declared;
+  }
+  return schemaRole ? [{ type: schemaRole }] : [];
+}
+
+/** Same resolution as above without the conflict warning. */
+export function includesEntityType(
+  type: string,
+  schemaRole: string | undefined,
+  jsonLd?: PageJsonLdInput,
+): boolean {
+  const declared = declaredEntities(jsonLd);
+  if (declared.length) {
+    return declared.some((entry) => entry.type === type);
+  }
+  return schemaRole === type;
+}

--- a/site/app/utils/siteMeta.ts
+++ b/site/app/utils/siteMeta.ts
@@ -1,0 +1,75 @@
+export type SiteSoftwareMeta = {
+  name: string;
+  codeRepository: string;
+  license: string;
+  programmingLanguage: string[];
+};
+
+export type SiteMeta = {
+  siteName: string;
+  siteUrl: string;
+  siteVersion: string;
+  description: string;
+  githubUrl: string;
+  footerText: string;
+  software: SiteSoftwareMeta;
+  /** Authored Organization properties; null disables the entity entirely. */
+  organization: Record<string, unknown> | null;
+  /** Raw JSON-LD entities appended to every page. */
+  jsonLdExtra: Record<string, unknown>[];
+};
+
+export const defaultSiteMeta: SiteMeta = {
+  siteName: "jp-local-gov-id",
+  siteUrl: "https://jplocalgov.oss.b4m.jp",
+  siteVersion: "",
+  description: "Documentation for the jp-local-gov-id library",
+  githubUrl: "https://github.com/b4moss/jp-local-gov-id",
+  footerText: "MIT License · 2026 Bicycle for Mind LLC.",
+  software: {
+    name: "jp-local-gov-id",
+    codeRepository: "https://github.com/b4moss/jp-local-gov-id",
+    license: "MIT",
+    programmingLanguage: ["TypeScript"],
+  },
+  organization: null,
+  jsonLdExtra: [],
+};
+
+type RawSiteMeta = Partial<Omit<SiteMeta, "software">> & {
+  software?: Partial<SiteSoftwareMeta>;
+};
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+export function normalizeSiteMeta(raw: RawSiteMeta | null | undefined): SiteMeta {
+  const base = { ...defaultSiteMeta, ...(raw || {}) };
+  const siteName = String(base.siteName || defaultSiteMeta.siteName);
+  const githubUrl = String(base.githubUrl || defaultSiteMeta.githubUrl);
+  const softwareRaw = raw?.software || {};
+
+  return {
+    siteName,
+    siteUrl: String(base.siteUrl || defaultSiteMeta.siteUrl).replace(/\/$/, ""),
+    siteVersion: String(base.siteVersion ?? ""),
+    description: String(base.description ?? ""),
+    githubUrl,
+    footerText: String(base.footerText || defaultSiteMeta.footerText),
+    software: {
+      name: String(softwareRaw.name || siteName),
+      codeRepository: String(softwareRaw.codeRepository || githubUrl),
+      license: String(softwareRaw.license || defaultSiteMeta.software.license),
+      programmingLanguage: Array.isArray(softwareRaw.programmingLanguage)
+        ? softwareRaw.programmingLanguage.map(String)
+        : [],
+    },
+    organization: isPlainObject(raw?.organization)
+      ? (raw.organization as Record<string, unknown>)
+      : null,
+    jsonLdExtra: Array.isArray(raw?.jsonLdExtra)
+      ? (raw.jsonLdExtra as Record<string, unknown>[])
+      : [],
+  };
+}

--- a/site/content.config.ts
+++ b/site/content.config.ts
@@ -1,4 +1,26 @@
-import { defineContentConfig, defineCollection } from "@nuxt/content";
+import { defineContentConfig, defineCollection, z } from "@nuxt/content";
+
+/**
+ * One JSON-LD entity. `type` is the only reserved key; everything else is
+ * passed through as schema.org properties and merged over the conventional
+ * defaults built by `useJsonLd()`.
+ */
+const jsonLdEntitySchema = z
+  .object({ type: z.string() })
+  .passthrough();
+
+const pageSchema = z.object({
+  /** Shorthand for a single entity. Equivalent to jsonLd.entities: [{ type }]. */
+  schemaRole: z.enum(["TechArticle", "HowTo", "FAQPage"]).optional(),
+  jsonLd: z
+    .object({
+      webPage: z.record(z.unknown()).optional(),
+      entities: z.array(jsonLdEntitySchema).optional(),
+      /** Emitted verbatim; no defaults are applied. */
+      extra: z.array(z.record(z.unknown())).optional(),
+    })
+    .optional(),
+});
 
 export default defineContentConfig({
   collections: {
@@ -8,6 +30,7 @@ export default defineContentConfig({
         include: "ja/**",
         prefix: "",
       },
+      schema: pageSchema,
     }),
     content_en: defineCollection({
       type: "page",
@@ -15,6 +38,7 @@ export default defineContentConfig({
         include: "en/**",
         prefix: "",
       },
+      schema: pageSchema,
     }),
   },
 });

--- a/site/content/en/index.md
+++ b/site/content/en/index.md
@@ -1,6 +1,7 @@
 ---
 title: Home
 description: npm packages for Japan’s nationwide local government codes
+schemaRole: TechArticle
 ---
 
 # jp-local-gov-id

--- a/site/content/ja/index.md
+++ b/site/content/ja/index.md
@@ -1,6 +1,7 @@
 ---
 title: ホーム
 description: 日本の全国地方公共団体コードを扱う npm パッケージ
+schemaRole: TechArticle
 ---
 
 # 全国地方公共団体コードヘルパ

--- a/site/i18n/locales/en.json
+++ b/site/i18n/locales/en.json
@@ -117,5 +117,9 @@
     "label": "Source language",
     "html": "HTML",
     "ts": "TypeScript"
+  },
+  "faq": {
+    "expandAll": "Expand all",
+    "collapseAll": "Collapse all"
   }
 }

--- a/site/i18n/locales/ja.json
+++ b/site/i18n/locales/ja.json
@@ -117,5 +117,9 @@
     "label": "ソースコード言語",
     "html": "HTML",
     "ts": "TypeScript"
+  },
+  "faq": {
+    "expandAll": "全部開く",
+    "collapseAll": "全部閉じる"
   }
 }

--- a/site/nuxt.config.ts
+++ b/site/nuxt.config.ts
@@ -1,9 +1,32 @@
-import { copyFileSync, readFileSync } from "node:fs";
+import { copyFileSync, existsSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { gt, valid } from "semver";
+import { parse as parseYaml } from "yaml";
+import { normalizeSiteMeta, type SiteMeta } from "./app/utils/siteMeta";
 
-const rootDir = join(dirname(fileURLToPath(import.meta.url)), "..");
+const siteRootDir = dirname(fileURLToPath(import.meta.url));
+const rootDir = join(siteRootDir, "..");
+
+function loadSiteMeta(): SiteMeta {
+  const candidates = [
+    join(siteRootDir, "site.meta.yaml"),
+    join(siteRootDir, "site.meta.yaml.example"),
+  ];
+  for (const path of candidates) {
+    if (!existsSync(path)) continue;
+    try {
+      const raw = parseYaml(readFileSync(path, "utf8")) as Record<
+        string,
+        unknown
+      > | null;
+      return normalizeSiteMeta(raw || undefined);
+    } catch (error) {
+      console.warn(`[doc-site] Failed to parse ${path}:`, error);
+    }
+  }
+  return normalizeSiteMeta(undefined);
+}
 
 function readPackageVersion(relativePath: string) {
   const pkg = JSON.parse(
@@ -41,6 +64,8 @@ async function resolveNpmLatestIncludingRc(
   }
 }
 
+const siteMeta = loadSiteMeta();
+
 const packageAppVersion = readPackageVersion(
   "packages/jp-local-gov-id/package.json",
 );
@@ -72,6 +97,15 @@ export default defineNuxtConfig({
     public: {
       appVersion,
       dataVersion,
+      siteName: siteMeta.siteName,
+      siteUrl: siteMeta.siteUrl,
+      siteVersion: siteMeta.siteVersion,
+      description: siteMeta.description,
+      githubUrl: siteMeta.githubUrl,
+      footerText: siteMeta.footerText,
+      software: siteMeta.software,
+      organization: siteMeta.organization,
+      jsonLdExtra: siteMeta.jsonLdExtra,
     },
   },
   // GTM: set NUXT_PUBLIC_SCRIPTS_GOOGLE_TAG_MANAGER_ID=GTM-XXXXXXX (build-time for SSG).
@@ -94,11 +128,10 @@ export default defineNuxtConfig({
     experimental: { sqliteConnector: "native" },
     build: {
       markdown: {
+        // Always-dark code blocks (incl. light UI). High-contrast tokens so no
+        // near-black github-light colors remain on the dark pre background.
         highlight: {
-          theme: {
-            default: "github-light",
-            dark: "github-dark",
-          },
+          theme: "github-dark-high-contrast",
         },
       },
     },
@@ -114,6 +147,8 @@ export default defineNuxtConfig({
     },
   },
   i18n: {
+    // Absolute URLs for canonical / hreflang come from site.meta.yaml.
+    baseUrl: siteMeta.siteUrl,
     locales: [
       { code: "ja", name: "日本語", language: "ja-JP", file: "ja.json" },
       { code: "en", name: "English", language: "en-US", file: "en.json" },
@@ -165,7 +200,9 @@ export default defineNuxtConfig({
         "/en/examples/nationwide-municipalities",
         "/ja/contribute",
         "/en/contribute",
+        "/sitemap.xml",
+        "/robots.txt",
       ],
     },
   },
-})
+});

--- a/site/package.json
+++ b/site/package.json
@@ -24,7 +24,8 @@
     "semver": "^7.8.5",
     "sucrase": "^3.35.0",
     "vue": "^3.5.35",
-    "vue-router": "^5.1.0"
+    "vue-router": "^5.1.0",
+    "yaml": "^2.9.0"
   },
   "devDependencies": {
     "@types/semver": "^7.8.0"

--- a/site/server/routes/robots.txt.get.ts
+++ b/site/server/routes/robots.txt.get.ts
@@ -1,0 +1,6 @@
+export default defineEventHandler((event) => {
+  const { siteUrl } = useRuntimeConfig().public;
+  const base = String(siteUrl || "https://example.com").replace(/\/$/, "");
+  setHeader(event, "Content-Type", "text/plain; charset=utf-8");
+  return `User-agent: *\nAllow: /\n\nSitemap: ${base}/sitemap.xml\n`;
+});

--- a/site/server/routes/sitemap.xml.get.ts
+++ b/site/server/routes/sitemap.xml.get.ts
@@ -1,0 +1,8 @@
+import { buildSitemapXml } from "~/utils/buildSitemap";
+
+export default defineEventHandler((event) => {
+  const { siteUrl } = useRuntimeConfig().public;
+  const xml = buildSitemapXml(String(siteUrl || "https://example.com"));
+  setHeader(event, "Content-Type", "application/xml; charset=utf-8");
+  return xml;
+});

--- a/site/site.meta.yaml.example
+++ b/site/site.meta.yaml.example
@@ -1,0 +1,20 @@
+# Copy this file to site.meta.yaml and edit for your deployment.
+# site.meta.yaml is gitignored; this example is used as fallback when absent.
+#
+# Site-wide settings feed runtimeConfig and JSON-LD SoftwareSourceCode on every page.
+# Page roles (TechArticle / FAQPage / HowTo) belong in Markdown frontmatter (schemaRole).
+# FAQ Q/A use ::faq-item in the body.
+
+siteName: jp-local-gov-id
+siteUrl: https://jplocalgov.oss.b4m.jp
+siteVersion: "1.0.0"
+description: Documentation for the jp-local-gov-id library — Japanese local government codes in the browser
+githubUrl: https://github.com/b4moss/jp-local-gov-id
+footerText: "MIT License · 2026 Bicycle for Mind LLC."
+
+software:
+  name: jp-local-gov-id
+  codeRepository: https://github.com/b4moss/jp-local-gov-id
+  license: MIT
+  programmingLanguage:
+    - TypeScript


### PR DESCRIPTION
## Summary
- Port `b4moss/git-template:doc-site` v0.9.0 features into `site/` via selective diff (not merge/cherry-pick)
- Add `site.meta.yaml` config, JSON-LD helpers, FAQ accordion components, `sitemap.xml` / `robots.txt`, light-mode contrast fixes, and mobile header dropdown hydrate fix
- Preserve jp-local-gov-id specifics: Playground, demos, `prepare-data`, npm version resolution, and `.field` CSS for live demos

## Test plan
- [x] `npm run build:site` succeeds
- [x] `site/.output/public/sitemap.xml` lists all docsNav routes with hreflang
- [x] `site/.output/public/robots.txt` references sitemap
- [x] `/ja/` HTML includes `application/ld+json` with TechArticle (index frontmatter)

Closes #95


Made with [Cursor](https://cursor.com)