### PR TITLE
fix(site): emit JSON-LD as script innerHTML for crawlers

### DIFF
--- a/site/app/composables/useJsonLd.ts
+++ b/site/app/composables/useJsonLd.ts
@@ -198,7 +198,9 @@ export function useJsonLd(options: UseJsonLdOptions) {
       {
         key: "json-ld",
         type: "application/ld+json",
-        children: JSON.stringify(graph.value),
+        // `children` is serialized as an HTML attribute in SSG output; use
+        // innerHTML so crawlers (Google Rich Results Test, etc.) read the JSON.
+        innerHTML: JSON.stringify(graph.value),
       },
     ]),
   });


### PR DESCRIPTION
## Summary
- Fix JSON-LD not being detected by Google Rich Results Test
- `useHead({ script: { children: ... } })` was rendered as a `children` HTML attribute on an empty `<script>` tag during SSG
- Switch to `innerHTML` so JSON-LD is written inside `<script type="application/ld+json">`

## Test plan
- [x] `npm run build:site`
- [x] `site/.output/public/ja/index.html` contains `<script type="application/ld+json">{...}</script>` (JSON inside tag, no `children=` attribute)


Made with [Cursor](https://cursor.com)