### PR TITLE
fix: OpenSSF Scorecard バッジ表示の修正 (#38)

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches:
       - main
-      - develop
 
 permissions: read-all
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![npm](https://img.shields.io/npm/v/@b4moss/jp-local-gov-id/rc)](https://www.npmjs.com/package/@b4moss/jp-local-gov-id)
 [![Release](https://img.shields.io/github/v/release/b4moss/jp-local-gov-id?include_prereleases&filter=app-v*)](https://github.com/b4moss/jp-local-gov-id/releases)
 [![License](https://img.shields.io/github/license/b4moss/jp-local-gov-id)](https://github.com/b4moss/jp-local-gov-id/blob/main/LICENSE)
-[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/b4moss/jp-local-gov-id/badge)](https://securityscorecards.dev/viewer/?uri=github.com/b4moss/jp-local-gov-id)
+[![OpenSSF Scorecard](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fapi.scorecard.dev%2Fprojects%2Fgithub.com%2Fb4moss%2Fjp-local-gov-id&label=OpenSSF%20Scorecard&query=$.score)](https://scorecard.dev/viewer/?uri=github.com/b4moss/jp-local-gov-id)
 
 [日本語](./README_ja.md)
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -5,7 +5,7 @@
 [![npm](https://img.shields.io/npm/v/@b4moss/jp-local-gov-id/rc)](https://www.npmjs.com/package/@b4moss/jp-local-gov-id)
 [![Release](https://img.shields.io/github/v/release/b4moss/jp-local-gov-id?include_prereleases&filter=app-v*)](https://github.com/b4moss/jp-local-gov-id/releases)
 [![License](https://img.shields.io/github/license/b4moss/jp-local-gov-id)](https://github.com/b4moss/jp-local-gov-id/blob/main/LICENSE)
-[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/b4moss/jp-local-gov-id/badge)](https://securityscorecards.dev/viewer/?uri=github.com/b4moss/jp-local-gov-id)
+[![OpenSSF Scorecard](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fapi.scorecard.dev%2Fprojects%2Fgithub.com%2Fb4moss%2Fjp-local-gov-id&label=OpenSSF%20Scorecard&query=$.score)](https://scorecard.dev/viewer/?uri=github.com/b4moss/jp-local-gov-id)
 
 [English](./README.md)
 


### PR DESCRIPTION
## Summary
- README / README_ja の OpenSSF Scorecard バッジを、旧 `api.securityscorecards.dev` から `api.scorecard.dev` の JSON を参照する dynamic badge に切り替え（`invalid repo path` 解消）
- ビューアリンクを `scorecard.dev/viewer` に更新
- Scorecard workflow の push トリガから `develop` を除外し、`main` のみに限定（#38 手順 B）

## Test plan
- [x] `https://img.shields.io/badge/dynamic/json?url=...api.scorecard.dev...` がスコア（例: 3.6）を返すことを確認
- [ ] マージ後、GitHub README 上で OpenSSF バッジがスコア表示になることを確認
- [ ] マージ後、OpenSSF Scorecard workflow が `main` push で success することを確認

Closes #38（OpenSSF バッジ部分）

Made with [Cursor](https://cursor.com)