### PR TITLE
chore: Dependabot 設定（npm / GitHub Actions）

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,36 @@
+# Dependabot opens update PRs only; no auto-merge.
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+    groups:
+      npm-production:
+        dependency-type: production
+        patterns:
+          - "*"
+      npm-development:
+        dependency-type: development
+        patterns:
+          - "*"
+
+  - package-ecosystem: npm
+    directory: /scripts
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
- `.github/dependabot.yml` を追加（npm ルート + `scripts/`、GitHub Actions）
- 週次で更新 PR を作成。auto-merge は設定していない

## Test plan
- [ ] マージ後、Dependabot が設定を認識することを確認
- [ ] 次回 Scorecard 実行で `DependencyUpdateToolID` alert が close されることを確認

Part 1/4 of Scorecard Code scanning remediation (#38)

Made with [Cursor](https://cursor.com)