### PR TITLE
fix: workflow token 権限を job レベルに限定

### DIFF
--- a/.github/workflows/monitor-source-hash.yml
+++ b/.github/workflows/monitor-source-hash.yml
@@ -12,14 +12,17 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: write
-  issues: write
+  contents: read
+  issues: read
 
 jobs:
   check:
     name: Check source hash
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: write
+      issues: write
 
     steps:
       - name: Checkout

--- a/.github/workflows/release-on-tag.yml
+++ b/.github/workflows/release-on-tag.yml
@@ -11,12 +11,14 @@ on:
       - "app-v*"
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- `monitor-source-hash.yml`: トップレベル `read`、commit/issue 用 job のみ `write`
- `release-on-tag.yml`: トップレベル `read`、release job のみ `contents: write`

## Test plan
- [ ] マージ後 Scorecard 実行で `TokenPermissionsID` alert 2件が close されること
- [ ] monitor workflow が JSON commit / issue 作成を継続できること
- [ ] release-on-tag が GitHub Release 作成を継続できること

Part 2/4 of Scorecard Code scanning remediation (#38)

Made with [Cursor](https://cursor.com)