### PR TITLE
feat: CodeQL SAST workflow 追加

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,8 @@
+name: jp-local-gov-id-codeql
+
+paths-ignore:
+  - "**/dist/**"
+  - "**/coverage/**"
+  - "**/.output/**"
+  - "**/.nuxt/**"
+  - "site/public/**"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,52 @@
+# CodeQL SAST — non-blocking (alerts go to Security > Code scanning).
+# Matches CI PR targets (develop / dev-*) plus main push for Scorecard SAST.
+name: CodeQL
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - develop
+      - "dev-*"
+  schedule:
+    - cron: "0 6 * * 1"
+
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  actions: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze (javascript-typescript)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [javascript-typescript]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@6f5948dfacef28e207b48d0905cf90c03365536d # v3.37.9
+        with:
+          languages: ${{ matrix.language }}
+          config-file: ./.github/codeql/codeql-config.yml
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@6f5948dfacef28e207b48d0905cf90c03365536d # v3.37.9
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@6f5948dfacef28e207b48d0905cf90c03365536d # v3.37.9
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary
- `.github/workflows/codeql.yml` を追加（javascript-typescript）
- トリガ: PR → `develop` / `dev-*`、push → `main`、週次 schedule
- **non-blocking**: alert が出ても workflow は通常 success（branch protection 未設定）
- `.github/codeql/codeql-config.yml` で `dist/`, `coverage/`, `.output/`, `.nuxt/`, `site/public/` を除外
- Actions は既存 workflow と同様 commit SHA ピン留め

## Test plan
- [ ] マージ後 `main` push で CodeQL workflow が success
- [ ] Security > Code scanning に CodeQL（`tool: CodeQL`）alert が載る
- [ ] 次回 Scorecard で `SASTID` alert が close / 改善
- [ ] Fuzzing は対象外（dismiss 推奨）

## Notes
- 初回は既存コードへの alert が出る可能性あり → Critical/High から順に確認
- 煩わしさを抑えるため PR ブロックにはしていない

Made with [Cursor](https://cursor.com)