### PR TITLE
feat(docs): doc-site → gh-pages デプロイとテンプレ殻の追従

### DIFF
--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -1,0 +1,40 @@
+# Docs CI — PRs targeting doc-site only.
+# Builds the documentation site; does not run app tests or app package build as a gate.
+# App CI (ci.yml) is intentionally out of scope for this branch.
+name: Docs CI
+
+on:
+  pull_request:
+    branches:
+      - doc-site
+
+concurrency:
+  group: docs-ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Docs Build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build site
+        env:
+          NITRO_PRESET: static
+        run: npm run build:site

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,5 @@
-# CI — PRs targeting develop or dev-* only.
+# CI — PRs targeting develop or dev-* only (app / library).
+# Docs PRs targeting doc-site use ci-docs.yml instead; this workflow does not run there.
 # Local pre-PR gate: npm run ci:local (nektos/act). See docs/ci-cd.md.
 name: CI
 

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,40 +1,30 @@
-name: Deploy Docs
+# Docs site → gh-pages branch
+# Push / merge to `doc-site` builds the site and deploys static output to `gh-pages`.
+# Independent of app CI (ci.yml) and npm releases (data-v* / app-v*).
+#
+# Ops: set GitHub Pages source to "Deploy from a branch" → gh-pages / (root).
 
-# Docs site → GitHub Pages
-# Tag: site-vX.Y.Z-doc.N (example: site-v0.6.0-doc.1)
-# Tag push alone deploys; independent of data-v* / app-v* npm releases.
+name: Deploy Docs
 
 on:
   push:
-    tags:
-      - "site-v*-doc.*"
+    branches:
+      - doc-site
 
 concurrency:
   group: pages
   cancel-in-progress: false
 
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+  contents: write
 
 jobs:
-  build:
-    name: Build docs site
+  deploy:
+    name: Build and deploy docs site
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
     steps:
-      - name: Validate tag
-        run: |
-          set -euo pipefail
-          tag="${GITHUB_REF_NAME}"
-          if [[ ! "$tag" =~ ^site-v[0-9]+\.[0-9]+\.[0-9]+-doc\.[0-9]+$ ]]; then
-            echo "::error::Unsupported tag '${tag}'. Use site-vX.Y.Z-doc.N (e.g. site-v0.6.0-doc.1)."
-            exit 1
-          fi
-          echo "Validated docs tag: ${tag}"
-
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -44,9 +34,6 @@ jobs:
           node-version: 24
           cache: npm
 
-      - name: Setup Pages
-        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
-
       - name: Install dependencies
         run: npm ci
 
@@ -55,21 +42,13 @@ jobs:
           NITRO_PRESET: static
           NUXT_PUBLIC_SCRIPTS_GOOGLE_TAG_MANAGER_ID: ${{ vars.NUXT_PUBLIC_SCRIPTS_GOOGLE_TAG_MANAGER_ID }}
         run: npm run build:site
-      - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+
+      - name: Deploy to gh-pages
+        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4.1.0
         with:
-          path: site/.output/public
-
-  deploy:
-    name: Deploy to GitHub Pages
-    needs: build
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-
-    steps:
-      - name: Deploy
-        id: deployment
-        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: site/.output/public
+          publish_branch: gh-pages
+          force_orphan: true
+          # CNAME is already under site/public/ and copied into the generate output
+          enable_jekyll: false

--- a/.github/workflows/release-on-tag.yml
+++ b/.github/workflows/release-on-tag.yml
@@ -1,7 +1,7 @@
 # Create a GitHub Release when a data-v* or app-v* tag is pushed.
 # Operational rule: create these tags from the `release` branch so Publish
 # (publish.yml) can verify ancestry and reuse CI success for the tag SHA.
-# site-v* tags are handled by deploy-docs.yml, not this workflow.
+# Documentation site deploys from the `doc-site` branch (deploy-docs.yml), not tags.
 name: Release on tag
 
 on:
@@ -35,5 +35,5 @@ jobs:
           NOTES="Automated release for tag \`$TAG\`.
 
           npm publish tags (\`data-v*\` / \`app-v*\`) should be created from the \`release\` branch.
-          Documentation site tags (\`site-v*\`) use the Deploy docs workflow instead."
+          The documentation site deploys from the \`doc-site\` branch (not from tags)."
           gh release create "$TAG" --title "$TITLE" --notes "$NOTES"

--- a/docs/ci-cd.ja.md
+++ b/docs/ci-cd.ja.md
@@ -1,8 +1,8 @@
 # CI / CD
 
-GitHub Actions の発火条件、PR 前のローカル必須ゲート、npm publish と CI 履歴の関係をまとめます。
+GitHub Actions の発火条件、PR 前のローカル必須ゲート、npm publish と CI 履歴の関係、ドキュメントサイトの公開手順をまとめます。
 
-## ローカルゲート（PR 前必須）
+## ローカルゲート（アプリ PR 前必須）
 
 `develop` / `dev-*` 向けの PR を作成・更新する前に、**`act` の成功を必須**とします（人間・Cloud Agent 共通）。
 
@@ -24,24 +24,50 @@ npm run ci:local:fallback   # npm ci && npm test && npm run build
 
 ゲート失敗のまま PR しないでください。
 
-### エージェント向け
+### エージェント向け（アプリ / ライブラリ）
 
 1. `npm run ci:local` を実行（Docker が無いときだけ `ci:local:fallback`）
 2. 非 0 なら修正して再実行。PR 作成ツールはまだ呼ばない
 3. 成功後に PR を作成・更新する
 
-## CI（`.github/workflows/ci.yml`）
+## アプリ CI（`.github/workflows/ci.yml`）
 
 | 項目 | ルール |
 |------|--------|
 | トリガ | base が `develop` または `dev-*` の `pull_request` |
-| 発火しない例 | 任意ブランチへの push、`main` / `release` などへの PR |
+| 発火しない例 | 任意ブランチへの push、`main` / `release` / `doc-site` などへの PR |
 | 重いジョブのスキップ | 同一 head SHA に成功済みの `CI` ワークフローがある |
 | docs のみ | `docs/**`・`site/content/**`・`*.md` 等のみ → GitHub 上は Test/Build スキップ。ローカル act は原則フル実行 |
 | 並行 | `Gate` の後に `Test` と `Build` を並行 |
 | required check 名 | 集約ジョブ **`Test & Build`**（branch protection 互換） |
 
-対象外（従来どおり）: `deploy-docs.yml`（`site-v*`）、`scorecard.yml`。
+## Docs CI（`.github/workflows/ci-docs.yml`）
+
+| 項目 | ルール |
+|------|--------|
+| トリガ | base が `doc-site` の `pull_request` |
+| ジョブ | **`Docs Build`**: `npm ci` + `npm run build:site` |
+| 対象外 | アプリの `npm test`、アプリ単体の検証、およびアプリ CI の成否 — **`doc-site` へのマージ判定では無視** |
+
+### PR の向け先
+
+| 変更の種類 | PR 先 |
+|------------|--------|
+| ドキュメント / サイト（`site/**` など） | **`doc-site`** |
+| ライブラリ / データ / アプリ用スクリプト | 従来どおり `develop` または `dev-*` |
+
+Playground が参照するライブラリを、すでに `main` / `release` に入った内容へ追従させたいときだけ、そのブランチを `doc-site` に取り込む。アプリ CI の成否はマージ条件にしない。
+
+## Docs デプロイ（`.github/workflows/deploy-docs.yml`）
+
+| 項目 | ルール |
+|------|--------|
+| トリガ | **`doc-site`** への `push`（通常はマージ後） |
+| ビルド | `npm run build:site` → `site/.output/public` |
+| 公開 | **`gh-pages`** ブランチへ orphan force push |
+| 独立 | アプリ CI、`data-v*` / `app-v*` の npm リリース、旧 `site-v*` タグ（廃止）とは無関係 |
+
+**人手のリポジトリ設定:** GitHub Pages → Source = **Deploy from a branch** → `gh-pages` / `(root)`。カスタムドメイン `jplocalgov.oss.b4m.jp` は `site/public/CNAME` で維持する。
 
 ## ソース Excel 監視（`.github/workflows/monitor-source-hash.yml`）
 
@@ -62,13 +88,19 @@ npm run ci:local:fallback   # npm ci && npm test && npm run build
 | 履歴なし | Test + Build のあと publish |
 | dispatch | `force_test` で常に Test+Build 可能 |
 
-`data-v*` / `app-v*` タグは **`release` ブランチから**打つ。`release-on-tag.yml` はこれらのタグのみ自動 Release 作成（`site-v*` は docs 側）。
+`data-v*` / `app-v*` タグは **`release` ブランチから**打つ。`release-on-tag.yml` はこれらのタグのみ自動 Release 作成。
 
 ## 流れ
 
 ```text
+# アプリ / ライブラリ
 ローカル変更 → npm run ci:local（必須）
             → develop / dev-* へ PR
             → CI Gate → Test ‖ Build → "Test & Build"
 release 上のタグ → Release → Publish（CI 再利用 or 再検証）→ npm
+
+# ドキュメントサイト
+サイト変更 → doc-site へ PR
+          → Docs CI（"Docs Build"）
+          → doc-site へマージ → Deploy Docs → gh-pages → GitHub Pages
 ```

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -1,8 +1,8 @@
 # CI / CD
 
-This document describes when GitHub Actions runs, the mandatory local pre-PR gate, and how npm publish reuses CI history.
+This document describes when GitHub Actions runs, the mandatory local pre-PR gate, how npm publish reuses CI history, and how the documentation site is published.
 
-## Local gate (required before PR)
+## Local gate (required before app PR)
 
 Before opening or updating a pull request targeting `develop` or `dev-*`, **`act` must succeed** (developers and Cloud Agents).
 
@@ -24,24 +24,50 @@ npm run ci:local:fallback   # npm ci && npm test && npm run build
 
 Do not open or update a PR while this gate is failing.
 
-### Agents
+### Agents (app / library)
 
 1. Run `npm run ci:local` (or `ci:local:fallback` only when Docker is absent).
 2. If non-zero, fix and re-run; do not call the PR creation tool yet.
 3. Only then open/update the PR.
 
-## CI (`.github/workflows/ci.yml`)
+## App CI (`.github/workflows/ci.yml`)
 
 | Item | Rule |
 |------|------|
 | Trigger | `pull_request` whose **base** is `develop` or `dev-*` |
-| Not triggered | Push to arbitrary branches; PRs into `main` / `release` / other bases |
+| Not triggered | Push to arbitrary branches; PRs into `main` / `release` / `doc-site` / other bases |
 | Skip heavy jobs | Same head SHA already has a successful `CI` workflow run |
 | Docs-only | Changes limited to `docs/**`, `site/content/**`, `*.md` (and similar) → skip Test/Build on GitHub; local act still runs full jobs by default |
 | Parallelism | `Test` and `Build` jobs run in parallel after `Gate` |
 | Required check name | Aggregate job **`Test & Build`** (stable for branch protection) |
 
-Out of scope (unchanged): `deploy-docs.yml` (`site-v*`), `scorecard.yml`.
+## Docs CI (`.github/workflows/ci-docs.yml`)
+
+| Item | Rule |
+|------|------|
+| Trigger | `pull_request` whose **base** is `doc-site` |
+| Job | **`Docs Build`**: `npm ci` + `npm run build:site` |
+| Out of scope | App `npm test`, app package-only verification, and app CI success/failure — **ignored** for merging into `doc-site` |
+
+### PR targets
+
+| Change type | Open PR against |
+|-------------|-----------------|
+| Documentation / site (`site/**`, public docs content) | **`doc-site`** |
+| Library / data / app scripts | `develop` or `dev-*` (unchanged) |
+
+When the playground needs a newer published library build that already landed on `main` / `release`, merge that branch into `doc-site`. App CI status does not gate that merge.
+
+## Docs deploy (`.github/workflows/deploy-docs.yml`)
+
+| Item | Rule |
+|------|------|
+| Trigger | `push` to **`doc-site`** (typically after merge) |
+| Build | `npm run build:site` → `site/.output/public` |
+| Publish | Force-orphan commit to the **`gh-pages`** branch |
+| Independent of | App CI, `data-v*` / `app-v*` npm releases, and legacy `site-v*` tags (removed) |
+
+**Manual repo setting:** GitHub Pages → Source = **Deploy from a branch** → `gh-pages` / `(root)`. Custom domain `jplocalgov.oss.b4m.jp` is kept via `site/public/CNAME`.
 
 ## Source Excel monitor (`.github/workflows/monitor-source-hash.yml`)
 
@@ -62,13 +88,19 @@ Out of scope (unchanged): `deploy-docs.yml` (`site-v*`), `scorecard.yml`.
 | No CI history | Run Test + Build, then publish |
 | Dispatch | Optional `force_test` to always run Test+Build |
 
-Create `data-v*` / `app-v*` tags from the **`release`** branch. `release-on-tag.yml` auto-creates the GitHub Release for those tag patterns only (`site-v*` stays on the docs workflow).
+Create `data-v*` / `app-v*` tags from the **`release`** branch. `release-on-tag.yml` auto-creates the GitHub Release for those tag patterns only.
 
 ## Quick reference
 
 ```text
+# App / library
 local change → npm run ci:local (must pass)
             → open PR to develop / dev-*
             → CI Gate → Test ‖ Build → "Test & Build"
 tag on release → Release → Publish (reuse CI or re-verify) → npm
+
+# Documentation site
+site change → open PR to doc-site
+           → Docs CI ("Docs Build")
+           → merge to doc-site → Deploy Docs → gh-pages → GitHub Pages
 ```

--- a/site/app/components/DocsSidebar.vue
+++ b/site/app/components/DocsSidebar.vue
@@ -1,6 +1,20 @@
 <script setup lang="ts">
+type NavItem = {
+  key: string;
+  path: string;
+  parent?: string;
+  label: string;
+  to: string;
+};
+
+type NavGroup = {
+  parent: NavItem;
+  children: NavItem[];
+};
+
 const { items } = useDocsNav();
 const { open, close } = useSidebar();
+const { expandable, isOpen, toggle } = useDocsNavAccordion();
 const route = useRoute();
 const localePath = useLocalePath();
 
@@ -22,24 +36,116 @@ function isActive(item: { path: string; to: string }) {
   }
   return false;
 }
+
+const groups = computed((): Array<NavItem | NavGroup> => {
+  const list = items.value as NavItem[];
+  const byKey = new Map(list.map((item) => [item.key, item]));
+  const childrenByParent = new Map<string, NavItem[]>();
+  const childKeys = new Set<string>();
+
+  for (const item of list) {
+    if (!item.parent) {
+      continue;
+    }
+    const siblings = childrenByParent.get(item.parent) ?? [];
+    siblings.push(item);
+    childrenByParent.set(item.parent, siblings);
+    childKeys.add(item.key);
+  }
+
+  const result: Array<NavItem | NavGroup> = [];
+  for (const item of list) {
+    if (childKeys.has(item.key)) {
+      continue;
+    }
+    const children = childrenByParent.get(item.key);
+    if (children?.length) {
+      result.push({ parent: item, children });
+      continue;
+    }
+    // Orphan child whose parent key is missing — render flat.
+    if (item.parent && !byKey.has(item.parent)) {
+      result.push(item);
+      continue;
+    }
+    result.push(item);
+  }
+  return result;
+});
+
+function isGroup(entry: NavItem | NavGroup): entry is NavGroup {
+  return "children" in entry;
+}
+
+function onToggle(parentKey: string, event: Event) {
+  event.preventDefault();
+  event.stopPropagation();
+  toggle(parentKey);
+}
 </script>
 
 <template>
   <aside class="sidebar" :class="{ open }" aria-label="Docs">
     <nav class="sidebar-nav">
-      <NuxtLink
-        v-for="item in items"
-        :key="item.key"
-        :to="item.to"
-        class="sidebar-link"
-        :class="{
-          'sidebar-link--child': Boolean(item.parent),
-          'router-link-exact-active': isActive(item),
-        }"
-        @click="close"
+      <template
+        v-for="entry in groups"
+        :key="isGroup(entry) ? entry.parent.key : entry.key"
       >
-        {{ item.label }}
-      </NuxtLink>
+        <template v-if="isGroup(entry)">
+          <div
+            class="sidebar-group"
+            :data-open="isOpen(entry.parent.key) ? 'true' : 'false'"
+          >
+            <div class="sidebar-parent">
+              <NuxtLink
+                :to="entry.parent.to"
+                class="sidebar-link sidebar-link--parent"
+                :class="{ 'router-link-exact-active': isActive(entry.parent) }"
+                @click="close"
+              >
+                {{ entry.parent.label }}
+              </NuxtLink>
+              <button
+                v-if="expandable"
+                type="button"
+                class="sidebar-toggle"
+                :aria-expanded="isOpen(entry.parent.key)"
+                :aria-controls="`nav-group-${entry.parent.key}`"
+                :aria-label="entry.parent.label"
+                @click="onToggle(entry.parent.key, $event)"
+              >
+                <span class="sidebar-chevron" aria-hidden="true" />
+              </button>
+            </div>
+            <div
+              v-show="!expandable || isOpen(entry.parent.key)"
+              :id="`nav-group-${entry.parent.key}`"
+              class="sidebar-children"
+              role="group"
+            >
+              <NuxtLink
+                v-for="child in entry.children"
+                :key="child.key"
+                :to="child.to"
+                class="sidebar-link sidebar-link--child"
+                :class="{ 'router-link-exact-active': isActive(child) }"
+                @click="close"
+              >
+                {{ child.label }}
+              </NuxtLink>
+            </div>
+          </div>
+        </template>
+        <NuxtLink
+          v-else
+          :to="entry.to"
+          class="sidebar-link"
+          :class="{ 'router-link-exact-active': isActive(entry) }"
+          @click="close"
+        >
+          {{ entry.label }}
+        </NuxtLink>
+      </template>
     </nav>
   </aside>
   <button
@@ -65,15 +171,32 @@ function isActive(item: { path: string; to: string }) {
   overflow-y: auto;
   transform: translateX(-100%);
   transition: transform 0.2s ease;
+  /* Off-canvas menus can still intercept taps on iOS Safari unless disabled. */
+  pointer-events: none;
+  visibility: hidden;
 }
 
 .sidebar.open {
   transform: translateX(0);
+  pointer-events: auto;
+  visibility: visible;
 }
 
 .sidebar-nav {
   display: flex;
   flex-direction: column;
+  gap: 0.15rem;
+}
+
+.sidebar-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.sidebar-parent {
+  display: flex;
+  align-items: center;
   gap: 0.15rem;
 }
 
@@ -85,6 +208,11 @@ function isActive(item: { path: string; to: string }) {
   text-decoration: none;
   font-size: 0.9375rem;
   font-weight: 500;
+}
+
+.sidebar-link--parent {
+  flex: 1;
+  min-width: 0;
 }
 
 .sidebar-link:hover {
@@ -104,6 +232,46 @@ function isActive(item: { path: string; to: string }) {
   font-weight: 600;
 }
 
+.sidebar-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 1.85rem;
+  height: 1.85rem;
+  border: 0;
+  border-radius: 0.3rem;
+  background: transparent;
+  color: var(--color-muted);
+  cursor: pointer;
+  padding: 0;
+}
+
+.sidebar-toggle:hover {
+  color: var(--color-ink);
+  background: var(--color-accent-soft);
+}
+
+.sidebar-chevron {
+  width: 0.4rem;
+  height: 0.4rem;
+  border-right: 1.5px solid currentColor;
+  border-bottom: 1.5px solid currentColor;
+  transform: rotate(45deg);
+  transition: transform 0.15s ease;
+  opacity: 0.75;
+}
+
+.sidebar-group[data-open="true"] .sidebar-chevron {
+  transform: translateY(1px) rotate(-135deg);
+}
+
+.sidebar-children {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
 .sidebar-backdrop {
   position: fixed;
   inset: var(--header-height) 0 0;
@@ -121,6 +289,8 @@ function isActive(item: { path: string; to: string }) {
     height: calc(100vh - var(--header-height));
     transform: none;
     flex-shrink: 0;
+    pointer-events: auto;
+    visibility: visible;
   }
 
   .sidebar-backdrop {

--- a/site/app/components/HeaderDropdown.vue
+++ b/site/app/components/HeaderDropdown.vue
@@ -2,11 +2,18 @@
 withDefaults(
   defineProps<{
     label: string;
-    triggerText: string;
+    triggerText?: string;
     compactText?: string;
+    /** Icon-only trigger (e.g. gear). Uses #trigger slot when provided. */
+    iconOnly?: boolean;
+    /** Nested dropdowns sit inside another menu; tighten layout. */
+    nested?: boolean;
   }>(),
   {
+    triggerText: "",
     compactText: "",
+    iconOnly: false,
+    nested: false,
   },
 );
 
@@ -69,7 +76,12 @@ defineExpose({ close, open });
 </script>
 
 <template>
-  <div ref="root" class="dropdown" :data-open="open ? 'true' : 'false'">
+  <div
+    ref="root"
+    class="dropdown"
+    :class="{ 'dropdown--nested': nested, 'dropdown--icon': iconOnly }"
+    :data-open="open ? 'true' : 'false'"
+  >
     <button
       :id="triggerId"
       type="button"
@@ -80,11 +92,20 @@ defineExpose({ close, open });
       :aria-controls="listId"
       @click="toggle"
     >
-      <span class="trigger-text trigger-text--full">{{ triggerText }}</span>
-      <span class="trigger-text trigger-text--compact">
-        {{ compactText || triggerText }}
-      </span>
-      <span class="chevron" aria-hidden="true" />
+      <slot name="trigger">
+        <template v-if="!iconOnly">
+          <span class="trigger-text trigger-text--full">{{ triggerText }}</span>
+          <span class="trigger-text trigger-text--compact">
+            {{ compactText || triggerText }}
+          </span>
+          <span class="chevron" aria-hidden="true" />
+        </template>
+      </slot>
+      <span
+        v-if="!iconOnly && $slots.trigger"
+        class="chevron"
+        aria-hidden="true"
+      />
     </button>
     <div
       v-show="open"
@@ -119,6 +140,39 @@ defineExpose({ close, open });
   cursor: pointer;
 }
 
+.dropdown--icon .dropdown-trigger {
+  justify-content: center;
+  width: 2.25rem;
+  padding: 0;
+  color: var(--color-muted);
+}
+
+.dropdown--icon .dropdown-trigger:hover {
+  color: var(--color-ink);
+}
+
+.dropdown--nested {
+  width: 100%;
+}
+
+.dropdown--nested .dropdown-trigger {
+  width: 100%;
+  justify-content: space-between;
+  min-height: 2.1rem;
+  font-size: 0.875rem;
+}
+
+.dropdown--nested .dropdown-menu {
+  position: static;
+  top: auto;
+  right: auto;
+  margin-top: 0.25rem;
+  min-width: 0;
+  width: 100%;
+  box-shadow: none;
+  background: color-mix(in srgb, var(--color-bg) 55%, var(--color-surface));
+}
+
 .dropdown-trigger:hover {
   background: var(--color-accent-soft);
 }
@@ -138,6 +192,7 @@ defineExpose({ close, open });
   border-bottom: 1.5px solid currentColor;
   transform: translateY(-1px) rotate(45deg);
   opacity: 0.7;
+  flex-shrink: 0;
 }
 
 .dropdown[data-open="true"] .chevron {
@@ -158,17 +213,17 @@ defineExpose({ close, open });
 }
 
 @media (max-width: 640px) {
-  .dropdown-trigger {
+  .dropdown:not(.dropdown--icon):not(.dropdown--nested) .dropdown-trigger {
     min-width: 2.25rem;
     justify-content: center;
     padding: 0.35rem 0.45rem;
   }
 
-  .trigger-text--full {
+  .dropdown:not(.dropdown--icon):not(.dropdown--nested) .trigger-text--full {
     display: none;
   }
 
-  .trigger-text--compact {
+  .dropdown:not(.dropdown--icon):not(.dropdown--nested) .trigger-text--compact {
     display: inline;
     font-size: 0.8rem;
     font-weight: 600;
@@ -178,6 +233,11 @@ defineExpose({ close, open });
   .dropdown-menu {
     min-width: 11rem;
     padding: 0.4rem;
+  }
+
+  .dropdown--nested .dropdown-trigger {
+    min-height: 2.4rem;
+    font-size: 0.95rem;
   }
 }
 </style>

--- a/site/app/components/HeaderPrefsMenu.vue
+++ b/site/app/components/HeaderPrefsMenu.vue
@@ -23,9 +23,9 @@ const languageOptions = computed(() => {
 });
 
 const themeOptions = computed(() => [
-  { value: "system", label: t("theme.system"), compact: "Sys" },
-  { value: "light", label: t("theme.light"), compact: "Lt" },
-  { value: "dark", label: t("theme.dark"), compact: "Dk" },
+  { value: "system", label: t("theme.system") },
+  { value: "light", label: t("theme.light") },
+  { value: "dark", label: t("theme.dark") },
 ]);
 
 const currentLanguage = computed(() => {
@@ -39,80 +39,120 @@ const currentTheme = computed(
     themeOptions.value[0],
 );
 
-const triggerText = computed(
-  () => `${currentLanguage.value} · ${currentTheme.value.label}`,
-);
-
-const compactText = computed(() => {
-  const lang =
-    locale.value === "ja" ? "JA" : locale.value === "en" ? "EN" : locale.value.toUpperCase();
-  return `${lang} · ${currentTheme.value.compact}`;
-});
-
-async function chooseLanguage(code: string, close: () => void) {
+async function chooseLanguage(code: string, closeOuter: () => void) {
   if (code !== locale.value) {
     await setLocale(code);
   }
-  close();
+  closeOuter();
 }
 
-function chooseTheme(value: string, close: () => void) {
+function chooseTheme(value: string, closeOuter: () => void) {
   colorMode.preference = value;
-  close();
+  closeOuter();
 }
 </script>
 
 <template>
-  <HeaderDropdown
-    :label="t('nav.prefs')"
-    :trigger-text="triggerText"
-    :compact-text="compactText"
-  >
+  <HeaderDropdown :label="t('nav.prefs')" icon-only>
+    <template #trigger>
+      <svg
+        class="gear-icon"
+        viewBox="0 0 24 24"
+        width="18"
+        height="18"
+        aria-hidden="true"
+      >
+        <path
+          fill="currentColor"
+          d="M19.14 12.94c.04-.31.06-.63.06-.94s-.02-.63-.06-.94l2.03-1.58a.49.49 0 0 0 .12-.61l-1.92-3.32a.49.49 0 0 0-.59-.22l-2.39.96c-.5-.38-1.03-.7-1.62-.94l-.36-2.54a.48.48 0 0 0-.48-.41h-3.84a.48.48 0 0 0-.48.41l-.36 2.54c-.59.24-1.13.57-1.62.94l-2.39-.96a.49.49 0 0 0-.59.22L2.74 8.87a.48.48 0 0 0 .12.61l2.03 1.58c-.04.31-.06.63-.06.94s.02.63.06.94L2.86 14.5a.49.49 0 0 0-.12.61l1.92 3.32c.12.22.37.3.59.22l2.39-.96c.5.38 1.03.7 1.62.94l.36 2.54c.05.24.24.41.48.41h3.84c.24 0 .44-.17.48-.41l.36-2.54c.59-.24 1.13-.57 1.62-.94l2.39.96c.22.08.47 0 .59-.22l1.92-3.32a.49.49 0 0 0-.12-.61l-2.03-1.58zM12 15.6A3.6 3.6 0 1 1 12 8.4a3.6 3.6 0 0 1 0 7.2z"
+        />
+      </svg>
+    </template>
+
     <template #default="{ close }">
-      <div class="section" role="group" :aria-label="t('nav.language')">
-        <p class="section-label">{{ t("nav.language") }}</p>
-        <button
-          v-for="item in languageOptions"
-          :key="item.code"
-          type="button"
-          class="option"
-          role="option"
-          :aria-selected="item.code === locale"
-          :data-active="item.code === locale ? 'true' : 'false'"
-          @click="chooseLanguage(item.code, close)"
-        >
-          {{ item.name }}
-        </button>
-      </div>
-      <div class="section" role="group" :aria-label="t('theme.label')">
-        <p class="section-label">{{ t("theme.label") }}</p>
-        <button
-          v-for="item in themeOptions"
-          :key="item.value"
-          type="button"
-          class="option"
-          role="option"
-          :aria-selected="item.value === colorMode.preference"
-          :data-active="item.value === colorMode.preference ? 'true' : 'false'"
-          @click="chooseTheme(item.value, close)"
-        >
-          {{ item.label }}
-        </button>
+      <div class="prefs-stack">
+        <div class="section" role="group" :aria-label="t('nav.language')">
+          <p class="section-label">{{ t("nav.language") }}</p>
+          <HeaderDropdown
+            nested
+            :label="t('nav.language')"
+            :trigger-text="currentLanguage"
+          >
+            <template #default="{ close: closeLang }">
+              <button
+                v-for="item in languageOptions"
+                :key="item.code"
+                type="button"
+                class="option"
+                role="option"
+                :aria-selected="item.code === locale"
+                :data-active="item.code === locale ? 'true' : 'false'"
+                @click="
+                  chooseLanguage(item.code, () => {
+                    closeLang();
+                    close();
+                  })
+                "
+              >
+                {{ item.name }}
+              </button>
+            </template>
+          </HeaderDropdown>
+        </div>
+
+        <div class="section" role="group" :aria-label="t('theme.label')">
+          <p class="section-label">{{ t("theme.label") }}</p>
+          <HeaderDropdown
+            nested
+            :label="t('theme.label')"
+            :trigger-text="currentTheme.label"
+          >
+            <template #default="{ close: closeTheme }">
+              <button
+                v-for="item in themeOptions"
+                :key="item.value"
+                type="button"
+                class="option"
+                role="option"
+                :aria-selected="item.value === colorMode.preference"
+                :data-active="item.value === colorMode.preference ? 'true' : 'false'"
+                @click="
+                  chooseTheme(item.value, () => {
+                    closeTheme();
+                    close();
+                  })
+                "
+              >
+                {{ item.label }}
+              </button>
+            </template>
+          </HeaderDropdown>
+        </div>
       </div>
     </template>
   </HeaderDropdown>
 </template>
 
 <style scoped>
+.gear-icon {
+  display: block;
+}
+
+.prefs-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  min-width: 12rem;
+}
+
 .section + .section {
-  margin-top: 0.35rem;
   padding-top: 0.35rem;
   border-top: 1px solid var(--color-border);
 }
 
 .section-label {
   margin: 0;
-  padding: 0.25rem 0.65rem 0.15rem;
+  padding: 0.25rem 0.35rem 0.2rem;
   color: var(--color-muted);
   font-size: 0.7rem;
   font-weight: 600;

--- a/site/app/components/SiteHeader.vue
+++ b/site/app/components/SiteHeader.vue
@@ -4,7 +4,8 @@ const localePath = useLocalePath();
 const { open, toggle } = useSidebar();
 const config = useRuntimeConfig();
 
-const githubUrl = "https://github.com/b4moss/jp-local-gov-id";
+const githubUrl = computed(() => String(config.public.githubUrl || ""));
+const npmUrl = computed(() => String(config.public.npmUrl || ""));
 const appVersion = computed(() => String(config.public.appVersion ?? ""));
 const dataVersion = computed(() => String(config.public.dataVersion ?? ""));
 </script>
@@ -42,7 +43,8 @@ const dataVersion = computed(() => String(config.public.dataVersion ?? ""));
       <div class="header-actions">
         <HeaderPrefsMenu />
         <a
-          class="github-link"
+          v-if="githubUrl"
+          class="ext-link"
           :href="githubUrl"
           target="_blank"
           rel="noopener noreferrer"
@@ -50,7 +52,7 @@ const dataVersion = computed(() => String(config.public.dataVersion ?? ""));
           :title="t('nav.github')"
         >
           <svg
-            class="github-icon"
+            class="ext-icon"
             viewBox="0 0 16 16"
             width="20"
             height="20"
@@ -59,6 +61,28 @@ const dataVersion = computed(() => String(config.public.dataVersion ?? ""));
             <path
               fill="currentColor"
               d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8"
+            />
+          </svg>
+        </a>
+        <a
+          v-if="npmUrl"
+          class="ext-link"
+          :href="npmUrl"
+          target="_blank"
+          rel="noopener noreferrer"
+          :aria-label="t('nav.npm')"
+          :title="t('nav.npm')"
+        >
+          <svg
+            class="ext-icon"
+            viewBox="0 0 16 16"
+            width="20"
+            height="20"
+            aria-hidden="true"
+          >
+            <path
+              fill="currentColor"
+              d="M0 0v16h16V0H0zm13 13h-2V5H8v8H3V3h10v10z"
             />
           </svg>
         </a>
@@ -179,7 +203,7 @@ const dataVersion = computed(() => String(config.public.dataVersion ?? ""));
   flex-shrink: 0;
 }
 
-.github-link {
+.ext-link {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -190,7 +214,7 @@ const dataVersion = computed(() => String(config.public.dataVersion ?? ""));
   text-decoration: none;
 }
 
-.github-link:hover {
+.ext-link:hover {
   color: var(--color-ink);
   background: var(--color-accent-soft);
 }

--- a/site/app/composables/useDocsNav.ts
+++ b/site/app/composables/useDocsNav.ts
@@ -1,35 +1,7 @@
-export type DocsNavItem = {
-  key: string;
-  path: string;
-  /** When set, item is a child of this nav key (shown indented in sidebar). */
-  parent?: string;
-};
+import { docsNavItems } from "~/config/docsNav";
 
-export const docsNavItems: DocsNavItem[] = [
-  { key: "home", path: "/" },
-  { key: "gettingStarted", path: "/getting-started" },
-  { key: "installation", path: "/installation" },
-  { key: "usage", path: "/usage" },
-  { key: "api", path: "/api" },
-  { key: "examples", path: "/examples" },
-  {
-    key: "examplesAddressInput",
-    path: "/examples/address-input",
-    parent: "examples",
-  },
-  {
-    key: "examplesMunicipalityValidation",
-    path: "/examples/municipality-validation",
-    parent: "examples",
-  },
-  {
-    key: "examplesNationwideMunicipalities",
-    path: "/examples/nationwide-municipalities",
-    parent: "examples",
-  },
-  { key: "playground", path: "/playground" },
-  { key: "contribute", path: "/contribute" },
-];
+export type { DocsNavItem } from "~/config/docsNav";
+export { docsNavItems } from "~/config/docsNav";
 
 function normalizePath(path: string) {
   if (!path || path === "/") return "/";

--- a/site/app/composables/useDocsNavAccordion.ts
+++ b/site/app/composables/useDocsNavAccordion.ts
@@ -1,0 +1,85 @@
+import { docsNavAccordion } from "~/config/docsNav";
+
+const STORAGE_KEY = "docs-nav-accordion";
+
+type OpenMap = Record<string, boolean>;
+
+function readStored(): OpenMap {
+  if (!import.meta.client) {
+    return {};
+  }
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return {};
+    }
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return {};
+    }
+    const result: OpenMap = {};
+    for (const [key, value] of Object.entries(
+      parsed as Record<string, unknown>,
+    )) {
+      if (typeof value === "boolean") {
+        result[key] = value;
+      }
+    }
+    return result;
+  } catch {
+    return {};
+  }
+}
+
+function writeStored(map: OpenMap) {
+  if (!import.meta.client || !docsNavAccordion.persist) {
+    return;
+  }
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(map));
+  } catch {
+    // ignore quota / private mode failures
+  }
+}
+
+export function useDocsNavAccordion() {
+  const openMap = useState<OpenMap>("docs-nav-accordion-open", () => ({}));
+
+  onMounted(() => {
+    if (!docsNavAccordion.persist) {
+      return;
+    }
+    openMap.value = readStored();
+  });
+
+  function isOpen(parentKey: string) {
+    if (!docsNavAccordion.expandable) {
+      return true;
+    }
+    if (docsNavAccordion.persist && parentKey in openMap.value) {
+      return openMap.value[parentKey];
+    }
+    return docsNavAccordion.defaultOpen;
+  }
+
+  function setOpen(parentKey: string, next: boolean) {
+    if (!docsNavAccordion.expandable) {
+      return;
+    }
+    openMap.value = { ...openMap.value, [parentKey]: next };
+    if (docsNavAccordion.persist) {
+      writeStored(openMap.value);
+    }
+  }
+
+  function toggle(parentKey: string) {
+    setOpen(parentKey, !isOpen(parentKey));
+  }
+
+  return {
+    expandable: docsNavAccordion.expandable,
+    isOpen,
+    setOpen,
+    toggle,
+  };
+}

--- a/site/app/config/docsNav.ts
+++ b/site/app/config/docsNav.ts
@@ -1,0 +1,48 @@
+export type DocsNavItem = {
+  key: string;
+  path: string;
+  /** When set, item is a child of this nav key (shown indented in sidebar). */
+  parent?: string;
+};
+
+/**
+ * Accordion behaviour for nested sidebar groups.
+ * - expandable: false → children always visible (legacy indent only)
+ * - defaultOpen: initial open state when expandable
+ * - persist: remember open/closed per parent key in localStorage
+ */
+export const docsNavAccordion = {
+  expandable: true,
+  defaultOpen: false,
+  persist: true,
+} as const;
+
+/**
+ * Edit this list to shape the docs sidebar / pager.
+ * Labels come from `i18n/locales/{ja,en}.json` → `nav.<key>`.
+ */
+export const docsNavItems: DocsNavItem[] = [
+  { key: "home", path: "/" },
+  { key: "gettingStarted", path: "/getting-started" },
+  { key: "installation", path: "/installation" },
+  { key: "usage", path: "/usage" },
+  { key: "api", path: "/api" },
+  { key: "examples", path: "/examples" },
+  {
+    key: "examplesAddressInput",
+    path: "/examples/address-input",
+    parent: "examples",
+  },
+  {
+    key: "examplesMunicipalityValidation",
+    path: "/examples/municipality-validation",
+    parent: "examples",
+  },
+  {
+    key: "examplesNationwideMunicipalities",
+    path: "/examples/nationwide-municipalities",
+    parent: "examples",
+  },
+  { key: "playground", path: "/playground" },
+  { key: "contribute", path: "/contribute" },
+];

--- a/site/app/utils/buildSitemap.ts
+++ b/site/app/utils/buildSitemap.ts
@@ -1,4 +1,4 @@
-import { docsNavItems } from "~/composables/useDocsNav";
+import { docsNavItems } from "~/config/docsNav";
 
 export const sitemapLocales = ["ja", "en"] as const;
 

--- a/site/app/utils/siteMeta.ts
+++ b/site/app/utils/siteMeta.ts
@@ -11,6 +11,8 @@ export type SiteMeta = {
   siteVersion: string;
   description: string;
   githubUrl: string;
+  /** Optional npm package page URL; empty hides the header npm icon. */
+  npmUrl: string;
   footerText: string;
   software: SiteSoftwareMeta;
   /** Authored Organization properties; null disables the entity entirely. */
@@ -25,6 +27,7 @@ export const defaultSiteMeta: SiteMeta = {
   siteVersion: "",
   description: "Documentation for the jp-local-gov-id library",
   githubUrl: "https://github.com/b4moss/jp-local-gov-id",
+  npmUrl: "https://www.npmjs.com/package/@b4moss/jp-local-gov-id",
   footerText: "MIT License · 2026 Bicycle for Mind LLC.",
   software: {
     name: "jp-local-gov-id",
@@ -48,6 +51,7 @@ export function normalizeSiteMeta(raw: RawSiteMeta | null | undefined): SiteMeta
   const base = { ...defaultSiteMeta, ...(raw || {}) };
   const siteName = String(base.siteName || defaultSiteMeta.siteName);
   const githubUrl = String(base.githubUrl || defaultSiteMeta.githubUrl);
+  const npmUrl = String(raw?.npmUrl ?? base.npmUrl ?? "");
   const softwareRaw = raw?.software || {};
 
   return {
@@ -56,6 +60,7 @@ export function normalizeSiteMeta(raw: RawSiteMeta | null | undefined): SiteMeta
     siteVersion: String(base.siteVersion ?? ""),
     description: String(base.description ?? ""),
     githubUrl,
+    npmUrl,
     footerText: String(base.footerText || defaultSiteMeta.footerText),
     software: {
       name: String(softwareRaw.name || siteName),

--- a/site/i18n/locales/en.json
+++ b/site/i18n/locales/en.json
@@ -16,6 +16,7 @@
     "prefs": "Display settings",
     "menu": "Menu",
     "github": "GitHub",
+    "npm": "npm",
     "prev": "Previous",
     "next": "Next",
     "pager": "Page navigation",

--- a/site/i18n/locales/ja.json
+++ b/site/i18n/locales/ja.json
@@ -16,6 +16,7 @@
     "prefs": "表示設定",
     "menu": "メニュー",
     "github": "GitHub",
+    "npm": "npm",
     "prev": "前へ",
     "next": "次へ",
     "pager": "ページナビゲーション",

--- a/site/nuxt.config.ts
+++ b/site/nuxt.config.ts
@@ -102,6 +102,7 @@ export default defineNuxtConfig({
       siteVersion: siteMeta.siteVersion,
       description: siteMeta.description,
       githubUrl: siteMeta.githubUrl,
+      npmUrl: siteMeta.npmUrl,
       footerText: siteMeta.footerText,
       software: siteMeta.software,
       organization: siteMeta.organization,
@@ -181,6 +182,9 @@ export default defineNuxtConfig({
     preset: "static",
     prerender: {
       crawlLinks: true,
+      // Relative Markdown links (./installation.md) are sometimes crawled as
+      // unprefixed /installation and /usage; real pages live under /ja|/en.
+      ignore: ["/installation", "/usage"],
       routes: [
         "/ja",
         "/en",

--- a/site/site.meta.yaml.example
+++ b/site/site.meta.yaml.example
@@ -10,6 +10,8 @@ siteUrl: https://jplocalgov.oss.b4m.jp
 siteVersion: "1.0.0"
 description: Documentation for the jp-local-gov-id library — Japanese local government codes in the browser
 githubUrl: https://github.com/b4moss/jp-local-gov-id
+# Header npm icon. Empty / unset hides it.
+npmUrl: https://www.npmjs.com/package/@b4moss/jp-local-gov-id
 footerText: "MIT License · 2026 Bicycle for Mind LLC."
 
 software:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

ドキュメント公開レーンを `site-v*` タグから **`doc-site` ブランチ**へ切り替え、マージ時に静的成果物を **`gh-pages`** へデプロイするようにしました。あわせて `b4moss/git-template` の `doc-site`（#63）殻 UI を `site/` に追従しています。

### デプロイ / CI
- [`deploy-docs.yml`](.github/workflows/deploy-docs.yml): `doc-site` への push で `npm run build:site` → `peaceiris/actions-gh-pages` で `gh-pages` へ orphan force push
- [`ci-docs.yml`](.github/workflows/ci-docs.yml)（新規）: base が `doc-site` の PR で **Docs Build** のみ（アプリ CI は不知）
- [`ci.yml`](.github/workflows/ci.yml) / [`release-on-tag.yml`](.github/workflows/release-on-tag.yml) / [`docs/ci-cd.md`](docs/ci-cd.md) / [`docs/ci-cd.ja.md`](docs/ci-cd.ja.md): 上記フローに合わせて更新
- 長期ブランチ `doc-site` を tip から push 済み

### テンプレ追従（製品固有は維持）
- [`site/app/config/docsNav.ts`](site/app/config/docsNav.ts) + [`useDocsNavAccordion`](site/app/composables/useDocsNavAccordion.ts) + サイドバー開閉 UI
- 歯車アイコンの prefs（入れ子ドロップダウン）
- ヘッダーに任意の `npmUrl` アイコン（`app` / `data` バージョン表示とブランドは維持）

### 手動オペレーション（必須）

GitHub リポジトリ設定で Pages の Source を切り替えてください。

1. **Settings → Pages**
2. Source: **Deploy from a branch**
3. Branch: **`gh-pages`** / folder: **`/(root)`**
4. カスタムドメイン `jplocalgov.oss.b4m.jp` は `site/public/CNAME` 経由で維持

初回は `doc-site` への push（本 tip で push 済み）または以降の `doc-site` 更新で `gh-pages` が生成・更新されます。`main` 側にも同じワークフローを載せるため、本 PR のマージが必要です。

## Test plan
- [x] `npm run build:site` が通る（ローカル確認済み）
- [ ] `doc-site` 向け PR で **Docs Build** のみが走る（アプリの Test & Build は出ない）
- [ ] `doc-site` へマージ/push 後に `gh-pages` が更新される
- [ ] Pages Source 切替後、カスタムドメインでサイトが表示される
- [ ] サイドバー: examples がアコーディオン開閉し、persist 時はリロード後も状態維持
- [ ] ヘッダー: 歯車メニューで言語・テーマ変更、`npmUrl` 設定時に npm アイコン表示

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a06ffd-76fb-7269-97bf-44e24f66ffa9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a06ffd-76fb-7269-97bf-44e24f66ffa9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

