### PR TITLE
fix(ci): #118 リリース CI 失敗の解消（Scorecard + rc.12 bump）

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -15,14 +15,19 @@ concurrency:
   group: pages
   cancel-in-progress: false
 
+# Scorecard Token-Permissions: keep top-level read-only; elevate only on the
+# deploy job. peaceiris/actions-gh-pages is a recognized pages deployer, so
+# job-level contents: write is expected and not scored as dangerous.
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   deploy:
     name: Build and deploy docs site
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout

--- a/.github/workflows/release-on-tag.yml
+++ b/.github/workflows/release-on-tag.yml
@@ -2,6 +2,8 @@
 # Operational rule: create these tags from the `release` branch so Publish
 # (publish.yml) can verify ancestry and reuse CI success for the tag SHA.
 # Documentation site deploys from the `doc-site` branch (deploy-docs.yml), not tags.
+#
+# Tag naming: use semver prerelease dots, e.g. app-v1.0.0-rc.12 (not app-v1.0.0-rc-12).
 name: Release on tag
 
 on:
@@ -31,6 +33,10 @@ jobs:
           TAG: ${{ github.ref_name }}
         run: |
           set -euo pipefail
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release for tag $TAG already exists; skipping create."
+            exit 0
+          fi
           TITLE="$TAG"
           NOTES="Automated release for tag \`$TAG\`.
 

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ A monorepo for Japan’s nationwide local government codes (npm workspaces).
 
 | Package | Description | Version |
 |---------|-------------|---------|
-| [`@b4moss/jp-local-gov-id`](./packages/jp-local-gov-id) | JS API (data not bundled; lazy-loaded) | 1.0.0-rc.11 |
-| [`@b4moss/jp-local-gov-id-data`](./packages/jp-local-gov-id-data) | `index.json` + Brotli binary (`.bin.br`) datasets | 1.0.0-rc.11 |
+| [`@b4moss/jp-local-gov-id`](./packages/jp-local-gov-id) | JS API (data not bundled; lazy-loaded) | 1.0.0-rc.12 |
+| [`@b4moss/jp-local-gov-id-data`](./packages/jp-local-gov-id-data) | `index.json` + Brotli binary (`.bin.br`) datasets | 1.0.0-rc.12 |
 
 ## Install (consumers)
 
@@ -57,7 +57,7 @@ Fetch from a versioned index URL:
 
 ```ts
 const client = await createLocalGovClient({
-  url: "https://example.com/jp-local-gov-id-data/1.0.0-rc.11/index.json",
+  url: "https://example.com/jp-local-gov-id-data/1.0.0-rc.12/index.json",
 });
 ```
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -15,8 +15,8 @@
 
 | パッケージ | 説明 | バージョン |
 |------------|------|------------|
-| [`@b4moss/jp-local-gov-id`](./packages/jp-local-gov-id) | JS API（データ非同梱・遅延ロード） | 1.0.0-rc.11 |
-| [`@b4moss/jp-local-gov-id-data`](./packages/jp-local-gov-id-data) | `index.json` + Brotli バイナリ（`.bin.br`）データ | 1.0.0-rc.11 |
+| [`@b4moss/jp-local-gov-id`](./packages/jp-local-gov-id) | JS API（データ非同梱・遅延ロード） | 1.0.0-rc.12 |
+| [`@b4moss/jp-local-gov-id-data`](./packages/jp-local-gov-id-data) | `index.json` + Brotli バイナリ（`.bin.br`）データ | 1.0.0-rc.12 |
 
 ## インストール（利用側）
 
@@ -57,7 +57,7 @@ await client.getLocalGovCodeByName("千代田区"); // "131016"
 
 ```ts
 const client = await createLocalGovClient({
-  url: "https://example.com/jp-local-gov-id-data/1.0.0-rc.11/index.json",
+  url: "https://example.com/jp-local-gov-id-data/1.0.0-rc.12/index.json",
 });
 ```
 

--- a/docs/main.md
+++ b/docs/main.md
@@ -109,7 +109,7 @@ import dataset from "@b4moss/jp-local-gov-id-data";
 const client = await createLocalGovClient({ data: dataset });
 
 const client = await createLocalGovClient({
-  url: "https://example.com/jp-local-gov-id-data/1.0.0-rc.11/index.json",
+  url: "https://example.com/jp-local-gov-id-data/1.0.0-rc.12/index.json",
 });
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17406,13 +17406,13 @@
     },
     "packages/jp-local-gov-id": {
       "name": "@b4moss/jp-local-gov-id",
-      "version": "1.0.0-rc.11",
+      "version": "1.0.0-rc.12",
       "license": "MIT",
       "dependencies": {
         "brotli-wasm": "^3.0.1"
       },
       "devDependencies": {
-        "@b4moss/jp-local-gov-id-data": "1.0.0-rc.11",
+        "@b4moss/jp-local-gov-id-data": "1.0.0-rc.12",
         "@vitest/coverage-v8": "^4",
         "typescript": "^7.0.2",
         "vite": "^8.2.2",
@@ -17425,7 +17425,7 @@
     },
     "packages/jp-local-gov-id-data": {
       "name": "@b4moss/jp-local-gov-id-data",
-      "version": "1.0.0-rc.11",
+      "version": "1.0.0-rc.12",
       "license": "MIT",
       "engines": {
         "node": ">=24"

--- a/packages/jp-local-gov-id-data/package.json
+++ b/packages/jp-local-gov-id-data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@b4moss/jp-local-gov-id-data",
-  "version": "1.0.0-rc.11",
+  "version": "1.0.0-rc.12",
   "description": "全国地方公共団体コードヘルパ — 日本の全国地方公共団体コードのデータ（Brotli 圧縮バイナリ）",
   "type": "module",
   "main": "./dataset.js",

--- a/packages/jp-local-gov-id/README.md
+++ b/packages/jp-local-gov-id/README.md
@@ -46,7 +46,7 @@ Fetch from a versioned index URL:
 
 ```ts
 const client = await createLocalGovClient({
-  url: "https://example.com/jp-local-gov-id-data/1.0.0-rc.11/index.json",
+  url: "https://example.com/jp-local-gov-id-data/1.0.0-rc.12/index.json",
 });
 ```
 

--- a/packages/jp-local-gov-id/README_ja.md
+++ b/packages/jp-local-gov-id/README_ja.md
@@ -46,7 +46,7 @@ await client.getLocalGovCodeByName("千代田区"); // "131016"
 
 ```ts
 const client = await createLocalGovClient({
-  url: "https://example.com/jp-local-gov-id-data/1.0.0-rc.11/index.json",
+  url: "https://example.com/jp-local-gov-id-data/1.0.0-rc.12/index.json",
 });
 ```
 

--- a/packages/jp-local-gov-id/package.json
+++ b/packages/jp-local-gov-id/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@b4moss/jp-local-gov-id",
-  "version": "1.0.0-rc.11",
+  "version": "1.0.0-rc.12",
   "description": "全国地方公共団体コードヘルパ — 日本の全国地方公共団体コードを扱う npm パッケージ",
   "type": "module",
   "main": "./dist/jp-local-gov-id.cjs",
@@ -45,7 +45,7 @@
     "access": "public"
   },
   "devDependencies": {
-    "@b4moss/jp-local-gov-id-data": "1.0.0-rc.11",
+    "@b4moss/jp-local-gov-id-data": "1.0.0-rc.12",
     "@vitest/coverage-v8": "^4",
     "typescript": "^7.0.2",
     "vite": "^8.2.2",

--- a/site/content/en/installation.md
+++ b/site/content/en/installation.md
@@ -44,12 +44,12 @@ For plain HTML, the minified IIFE build is simplest. APIs are exposed on the glo
 <!DOCTYPE html>
 <html lang="en">
   <body>
-    <script src="https://cdn.jsdelivr.net/npm/@b4moss/jp-local-gov-id@1.0.0-rc.11/dist/jp-local-gov-id.iife.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@b4moss/jp-local-gov-id@1.0.0-rc.12/dist/jp-local-gov-id.iife.min.js"></script>
     <script>
       const { createLocalGovClient } = JpLocalGovId;
 
       createLocalGovClient({
-        url: "https://cdn.jsdelivr.net/npm/@b4moss/jp-local-gov-id-data@1.0.0-rc.11/index.json",
+        url: "https://cdn.jsdelivr.net/npm/@b4moss/jp-local-gov-id-data@1.0.0-rc.12/index.json",
       }).then(async (client) => {
         console.log(await client.getByCode("131016"));
       });
@@ -69,10 +69,10 @@ The non-minified IIFE is `dist/jp-local-gov-id.iife.js`.
 <html lang="en">
   <body>
     <script type="module">
-      import { createLocalGovClient } from "https://cdn.jsdelivr.net/npm/@b4moss/jp-local-gov-id@1.0.0-rc.11/dist/jp-local-gov-id.js";
+      import { createLocalGovClient } from "https://cdn.jsdelivr.net/npm/@b4moss/jp-local-gov-id@1.0.0-rc.12/dist/jp-local-gov-id.js";
 
       const client = await createLocalGovClient({
-        url: "https://cdn.jsdelivr.net/npm/@b4moss/jp-local-gov-id-data@1.0.0-rc.11/index.json",
+        url: "https://cdn.jsdelivr.net/npm/@b4moss/jp-local-gov-id-data@1.0.0-rc.12/index.json",
       });
 
       console.log(await client.getByCode("131016"));

--- a/site/content/en/usage.md
+++ b/site/content/en/usage.md
@@ -78,7 +78,7 @@ const client = await createLocalGovClient({
 
 ```ts
 const client = await createLocalGovClient({
-  url: "https://cdn.jsdelivr.net/npm/@b4moss/jp-local-gov-id-data@1.0.0-rc.11/index.json",
+  url: "https://cdn.jsdelivr.net/npm/@b4moss/jp-local-gov-id-data@1.0.0-rc.12/index.json",
 });
 ```
 

--- a/site/content/ja/installation.md
+++ b/site/content/ja/installation.md
@@ -44,12 +44,12 @@ CDN では **JS（API）とデータ（版付き `index.json`）を同じ版で�
 <!DOCTYPE html>
 <html lang="ja">
   <body>
-    <script src="https://cdn.jsdelivr.net/npm/@b4moss/jp-local-gov-id@1.0.0-rc.11/dist/jp-local-gov-id.iife.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@b4moss/jp-local-gov-id@1.0.0-rc.12/dist/jp-local-gov-id.iife.min.js"></script>
     <script>
       const { createLocalGovClient } = JpLocalGovId;
 
       createLocalGovClient({
-        url: "https://cdn.jsdelivr.net/npm/@b4moss/jp-local-gov-id-data@1.0.0-rc.11/index.json",
+        url: "https://cdn.jsdelivr.net/npm/@b4moss/jp-local-gov-id-data@1.0.0-rc.12/index.json",
       }).then(async (client) => {
         console.log(await client.getByCode("131016"));
       });
@@ -69,10 +69,10 @@ CDN では **JS（API）とデータ（版付き `index.json`）を同じ版で�
 <html lang="ja">
   <body>
     <script type="module">
-      import { createLocalGovClient } from "https://cdn.jsdelivr.net/npm/@b4moss/jp-local-gov-id@1.0.0-rc.11/dist/jp-local-gov-id.js";
+      import { createLocalGovClient } from "https://cdn.jsdelivr.net/npm/@b4moss/jp-local-gov-id@1.0.0-rc.12/dist/jp-local-gov-id.js";
 
       const client = await createLocalGovClient({
-        url: "https://cdn.jsdelivr.net/npm/@b4moss/jp-local-gov-id-data@1.0.0-rc.11/index.json",
+        url: "https://cdn.jsdelivr.net/npm/@b4moss/jp-local-gov-id-data@1.0.0-rc.12/index.json",
       });
 
       console.log(await client.getByCode("131016"));

--- a/site/content/ja/usage.md
+++ b/site/content/ja/usage.md
@@ -133,7 +133,7 @@ module.exports = {
 
 ```ts
 const client = await createLocalGovClient({
-  url: "https://cdn.jsdelivr.net/npm/@b4moss/jp-local-gov-id-data@1.0.0-rc.11/index.json",
+  url: "https://cdn.jsdelivr.net/npm/@b4moss/jp-local-gov-id-data@1.0.0-rc.12/index.json",
 });
 ```
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

PR #118（`main` → `release` / `app-v1.0.0-rc.12`）で CI が落ちていた原因を解消します。

### 原因
1. **Scorecard（GHAS）**: `deploy-docs.yml` の top-level `contents: write` が Token-Permissions スコアを 0 にし、PR 上で high severity アラートとして失敗
2. **Release / Publish**: 誤タグ `app-v1.0.0-rc-12`（ハイフン、かつ `main` 起点）が打たれ、Release 重複作成と `release` 祖先チェックで失敗。誤 Release/タグは削除済み
3. **バージョン未バンプ**: パッケージがまだ `1.0.0-rc.11` のまま

### 変更
- `deploy-docs.yml`: top-level を `contents: read`、job-level で `contents: write`（peaceiris は Scorecard の pages 例外）
- `release-on-tag.yml`: 既存 Release がある場合はスキップ（冪等化）
- app / data を `1.0.0-rc.12` にバンプ

### マージ後の手順（#118 リリース）
1. **本 PR (#119) を `main` にマージ** → Scorecard 再実行で #118 のアラート解消を待つ
2. **#118（`main` → `release`）をマージ**
3. **`release` ブランチ上**で正しいタグを打つ（ドット区切り）:
   - `app-v1.0.0-rc.12`
   - 必要なら `data-v1.0.0-rc.12`
4. `Release on tag` → `Publish packages` が走る

## Test plan
- [x] ローカル `npm test` / `npm run build` 成功
- [x] CodeQL 成功
- [ ] 本 PR マージ後、main の Scorecard で Token-Permissions アラートが閉じること
- [ ] #118 の Scorecard チェックが緑になること
- [ ] release マージ後、正しいタグで Release / Publish が成功すること

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0702c-03d6-7180-b57a-c902182dc923?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0702c-03d6-7180-b57a-c902182dc923&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

