### PR TITLE
fix(docs): doc-site マージで Actions Pages デプロイ（gh-pages 廃止）

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,8 +1,9 @@
-# Docs site → gh-pages branch
-# Push / merge to `doc-site` builds the site and deploys static output to `gh-pages`.
-# Independent of app CI (ci.yml) and npm releases (data-v* / app-v*).
+# Docs site → GitHub Pages (Actions)
+# Push / merge to `doc-site` builds the static site and deploys via
+# actions/deploy-pages. No `gh-pages` branch.
 #
-# Ops: set GitHub Pages source to "Deploy from a branch" → gh-pages / (root).
+# Ops: GitHub Pages → Source = GitHub Actions.
+# Custom domain `jplocalgov.oss.b4m.jp` is kept via `site/public/CNAME`.
 
 name: Deploy Docs
 
@@ -16,11 +17,13 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: write
+  contents: read
+  pages: write
+  id-token: write
 
 jobs:
-  deploy:
-    name: Build and deploy docs site
+  build:
+    name: Build docs site
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
@@ -34,6 +37,9 @@ jobs:
           node-version: 24
           cache: npm
 
+      - name: Setup Pages
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
+
       - name: Install dependencies
         run: npm ci
 
@@ -43,12 +49,21 @@ jobs:
           NUXT_PUBLIC_SCRIPTS_GOOGLE_TAG_MANAGER_ID: ${{ vars.NUXT_PUBLIC_SCRIPTS_GOOGLE_TAG_MANAGER_ID }}
         run: npm run build:site
 
-      - name: Deploy to gh-pages
-        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4.1.0
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: site/.output/public
-          publish_branch: gh-pages
-          force_orphan: true
-          # CNAME is already under site/public/ and copied into the generate output
-          enable_jekyll: false
+          path: site/.output/public
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@368f82528645a54fb793d4d04e342629a3f51346 # v5.0.1

--- a/docs/ci-cd.ja.md
+++ b/docs/ci-cd.ja.md
@@ -64,10 +64,10 @@ Playground が参照するライブラリを、すでに `main` / `release` に�
 |------|--------|
 | トリガ | **`doc-site`** への `push`（通常はマージ後） |
 | ビルド | `npm run build:site` → `site/.output/public` |
-| 公開 | **`gh-pages`** ブランチへ orphan force push |
+| 公開 | GitHub Actions Pages（`upload-pages-artifact` → `deploy-pages`）。**`gh-pages` ブランチは使わない** |
 | 独立 | アプリ CI、`data-v*` / `app-v*` の npm リリース、旧 `site-v*` タグ（廃止）とは無関係 |
 
-**人手のリポジトリ設定:** GitHub Pages → Source = **Deploy from a branch** → `gh-pages` / `(root)`。カスタムドメイン `jplocalgov.oss.b4m.jp` は `site/public/CNAME` で維持する。
+**人手のリポジトリ設定:** GitHub Pages → Source = **GitHub Actions**。カスタムドメイン `jplocalgov.oss.b4m.jp` は `site/public/CNAME` で維持する。
 
 ## ソース Excel 監視（`.github/workflows/monitor-source-hash.yml`）
 
@@ -102,5 +102,6 @@ release 上のタグ → Release → Publish（CI 再利用 or 再検証）→ n
 # ドキュメントサイト
 サイト変更 → doc-site へ PR
           → Docs CI（"Docs Build"）
-          → doc-site へマージ → Deploy Docs → gh-pages → GitHub Pages
+          → doc-site へマージ → Deploy Docs → GitHub Pages（Actions）
 ```
+

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -64,10 +64,10 @@ When the playground needs a newer published library build that already landed on
 |------|------|
 | Trigger | `push` to **`doc-site`** (typically after merge) |
 | Build | `npm run build:site` → `site/.output/public` |
-| Publish | Force-orphan commit to the **`gh-pages`** branch |
+| Publish | GitHub Actions Pages (`upload-pages-artifact` → `deploy-pages`). **No `gh-pages` branch** |
 | Independent of | App CI, `data-v*` / `app-v*` npm releases, and legacy `site-v*` tags (removed) |
 
-**Manual repo setting:** GitHub Pages → Source = **Deploy from a branch** → `gh-pages` / `(root)`. Custom domain `jplocalgov.oss.b4m.jp` is kept via `site/public/CNAME`.
+**Manual repo setting:** GitHub Pages → Source = **GitHub Actions**. Custom domain `jplocalgov.oss.b4m.jp` is kept via `site/public/CNAME`.
 
 ## Source Excel monitor (`.github/workflows/monitor-source-hash.yml`)
 
@@ -102,5 +102,6 @@ tag on release → Release → Publish (reuse CI or re-verify) → npm
 # Documentation site
 site change → open PR to doc-site
            → Docs CI ("Docs Build")
-           → merge to doc-site → Deploy Docs → gh-pages → GitHub Pages
+           → merge to doc-site → Deploy Docs → GitHub Pages (Actions)
 ```
+


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`doc-site` へのマージ／push でドキュメントを公開する流れは維持しつつ、**`gh-pages` ブランチへの force push をやめて** GitHub Actions の Pages デプロイ（`configure-pages` → `upload-pages-artifact` → `deploy-pages`）に戻します。

現状のリポジトリ Pages 設定はすでに `build_type: workflow`（Source = GitHub Actions）なので、この変更のあと `doc-site` にマージすればそのまま公開される想定です。

### 変更
- [`.github/workflows/deploy-docs.yml`](.github/workflows/deploy-docs.yml): `peaceiris/actions-gh-pages` を削除し、Actions Pages ジョブに置換（トリガは引き続き `push` to `doc-site`）
- [`docs/ci-cd.md`](docs/ci-cd.md) / [`docs/ci-cd.ja.md`](docs/ci-cd.ja.md): 公開経路と手動設定（Source = GitHub Actions）を更新

### マージ後の確認
- [ ] Pages → Source が **GitHub Actions** のまま
- [ ] 本 PR を `doc-site` にマージ後、`Deploy Docs` が成功しサイトが更新される
- [ ] 不要になった `gh-pages` ブランチを削除してよい（任意）

## Test plan
- [ ] Docs CI（base=`doc-site`）で Docs Build が通る
- [ ] マージ後の Deploy Docs で build + deploy 両ジョブが成功する
- [ ] `jplocalgov.oss.b4m.jp` で新 UI（アコーディオン／歯車 prefs 等）が確認できる

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0703d-3450-7fb3-a345-5e7bcb09cd4f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0703d-3450-7fb3-a345-5e7bcb09cd4f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

