### PR TITLE
ci: CI/CD の冗長実行を削減

### DIFF
--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -31,8 +31,14 @@ jobs:
           node-version: 24
           cache: npm
 
-      - name: Install dependencies
-        run: npm ci
+      # Docs build needs site + library/data workspaces (not scripts).
+      - name: Install dependencies (site workspaces)
+        run: >
+          npm ci
+          -w jp-local-gov-id-site
+          -w @b4moss/jp-local-gov-id
+          -w @b4moss/jp-local-gov-id-data
+          --include-workspace-root
 
       - name: Build site
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,6 @@
-# CI — PRs targeting develop or dev-* (app / library), plus push to main/develop
-# for Codecov default-branch freshness (#121).
+# CI — PRs targeting develop or dev-* (app / library), plus push to main/release.
+# main: Codecov default-branch freshness (#121).
+# release: tag SHAs used by publish.yml get reusable CI success history.
 # Docs PRs targeting doc-site use ci-docs.yml instead; this workflow does not run there.
 # Local pre-PR gate: npm run ci:local (nektos/act). See docs/ci-cd.md.
 name: CI
@@ -9,11 +10,10 @@ on:
     branches:
       - develop
       - "dev-*"
-  # Keep Codecov default-branch / develop totals fresh for the #121 ≥90% gate.
   push:
     branches:
       - main
-      - develop
+      - release
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
@@ -104,82 +104,52 @@ jobs:
             core.setOutput('skip_heavy', 'false');
             core.setOutput('reason', 'full');
 
-  test:
-    name: Test
+  # Single job keeps required check name "Test & Build" and runs npm ci once.
+  # Always runs (even when skipping) so branch protection never sees a skipped check.
+  test-and-build:
+    name: Test & Build
     needs: gate
-    if: needs.gate.outputs.skip_heavy != 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
+      - name: Skip heavy work
+        if: needs.gate.outputs.skip_heavy == 'true'
+        run: |
+          echo "Heavy jobs skipped (${{ needs.gate.outputs.reason }}); treating as success."
+
       - name: Checkout
+        if: needs.gate.outputs.skip_heavy != 'true'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
+        if: needs.gate.outputs.skip_heavy != 'true'
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
           cache: npm
 
-      - name: Install dependencies
-        run: npm ci
+      # App CI does not need the Nuxt site workspace.
+      - name: Install dependencies (app workspaces)
+        if: needs.gate.outputs.skip_heavy != 'true'
+        run: >
+          npm ci
+          -w @b4moss/jp-local-gov-id
+          -w @b4moss/jp-local-gov-id-data
+          -w jp-local-gov-id-scripts
+          --include-workspace-root
 
       - name: Test with coverage
+        if: needs.gate.outputs.skip_heavy != 'true'
         run: npm test
 
+      - name: Build
+        if: needs.gate.outputs.skip_heavy != 'true'
+        run: npm run build
+
       - name: Upload coverage to Codecov
-        if: ${{ !env.ACT }}
+        if: ${{ needs.gate.outputs.skip_heavy != 'true' && !env.ACT }}
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: packages/jp-local-gov-id/coverage/lcov.info
           fail_ci_if_error: false
-          verbose: true
-
-  build:
-    name: Build
-    needs: gate
-    if: needs.gate.outputs.skip_heavy != 'true'
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - name: Setup Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: 24
-          cache: npm
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Build
-        run: npm run build
-
-  # Keeps branch-protection check name "Test & Build" stable.
-  result:
-    name: Test & Build
-    needs: [gate, test, build]
-    if: always()
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - name: Aggregate
-        run: |
-          set -euo pipefail
-          skip='${{ needs.gate.outputs.skip_heavy }}'
-          reason='${{ needs.gate.outputs.reason }}'
-          test_result='${{ needs.test.result }}'
-          build_result='${{ needs.build.result }}'
-          echo "skip_heavy=${skip} reason=${reason}"
-          echo "test=${test_result} build=${build_result}"
-          if [ "${skip}" = "true" ]; then
-            echo "Heavy jobs skipped (${reason}); treating as success."
-            exit 0
-          fi
-          if [ "${test_result}" = "success" ] && [ "${build_result}" = "success" ]; then
-            exit 0
-          fi
-          echo "::error::Test and/or Build did not succeed"
-          exit 1

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -39,8 +39,14 @@ jobs:
           node-version: 24
           cache: npm
 
-      - name: Install dependencies
-        run: npm ci
+      # Docs deploy needs site + library/data workspaces (not scripts).
+      - name: Install dependencies (site workspaces)
+        run: >
+          npm ci
+          -w jp-local-gov-id-site
+          -w @b4moss/jp-local-gov-id
+          -w @b4moss/jp-local-gov-id-data
+          --include-workspace-root
 
       - name: Build site
         env:

--- a/.github/workflows/monitor-source-hash.yml
+++ b/.github/workflows/monitor-source-hash.yml
@@ -36,8 +36,12 @@ jobs:
           node-version: 24
           cache: npm
 
-      - name: Install dependencies
-        run: npm ci
+      # Hash check only needs the scripts workspace (tsx / exceljs).
+      - name: Install dependencies (scripts workspace)
+        run: >
+          npm ci
+          -w jp-local-gov-id-scripts
+          --include-workspace-root
 
       - name: Check source hash
         id: check

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -113,7 +113,7 @@ jobs:
             );
             core.setOutput('skip_verify', ok ? 'true' : 'false');
             core.info(ok
-              ? `CI success found for ${sha} — skipping Test/Build`
+              ? `CI success found for ${sha} — skipping Test (Build always runs)`
               : `No CI success for ${sha} — will run Test+Build`);
 
       - name: Setup Node.js
@@ -123,15 +123,21 @@ jobs:
           registry-url: "https://registry.npmjs.org"
           cache: npm
 
-      - name: Install dependencies
-        run: npm ci
+      # Publish does not need the Nuxt site workspace.
+      - name: Install dependencies (app workspaces)
+        run: >
+          npm ci
+          -w @b4moss/jp-local-gov-id
+          -w @b4moss/jp-local-gov-id-data
+          -w jp-local-gov-id-scripts
+          --include-workspace-root
 
       - name: Test
         if: steps.ci_history.outputs.skip_verify != 'true'
         run: npm test
 
+      # dist/ is gitignored — always build before pack for app-v*.
       - name: Build
-        if: steps.ci_history.outputs.skip_verify != 'true'
         run: npm run build
 
       - name: Pack

--- a/.github/workflows/release-on-tag.yml
+++ b/.github/workflows/release-on-tag.yml
@@ -24,8 +24,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 0
 
       - name: Create release
         env:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -4,9 +4,8 @@ on:
   branch_protection_rule:
   schedule:
     - cron: "30 1 * * 1"
-  push:
-    branches:
-      - main
+  # Manual refresh when needed; avoid re-scoring on every main push.
+  workflow_dispatch:
 
 permissions: read-all
 

--- a/docs/ci-cd.ja.md
+++ b/docs/ci-cd.ja.md
@@ -34,19 +34,21 @@ npm run ci:local:fallback   # npm ci && npm test && npm run build
 
 | 項目 | ルール |
 |------|--------|
-| トリガ | base が `develop` または `dev-*` の `pull_request` |
-| 発火しない例 | 任意ブランチへの push、`main` / `release` / `doc-site` などへの PR |
-| 重いジョブのスキップ | 同一 head SHA に成功済みの `CI` ワークフローがある |
+| トリガ | base が `develop` または `dev-*` の `pull_request`、および **`main` / `release` への `push`** |
+| 発火しない例 | `develop` への push、任意ブランチへの push、`main` / `release` / `doc-site` などへの PR |
+| 重いジョブのスキップ | 同一 head SHA に成功済みの `CI` ワークフローがある、または docs のみの変更 |
 | docs のみ | `docs/**`・`site/content/**`・`*.md` 等のみ → GitHub 上は Test/Build スキップ。ローカル act は原則フル実行 |
-| 並行 | `Gate` の後に `Test` と `Build` を並行 |
-| required check 名 | 集約ジョブ **`Test & Build`**（branch protection 互換） |
+| ジョブ | `Gate` のあと **`Test & Build` 単一ジョブ**（`npm ci` 1回 → test → build）。site ワークスペースは入れない |
+| required check 名 | **`Test & Build`**（重い処理をスキップしてもジョブ自体は常に成功/失敗を報告） |
+| `main` push の理由 | Codecov default branch の coverage 更新（#121） |
+| `release` push の理由 | release 由来タグ SHA に CI 履歴を付け、publish の Test スキップを効かせる |
 
 ## Docs CI（`.github/workflows/ci-docs.yml`）
 
 | 項目 | ルール |
 |------|--------|
 | トリガ | base が `doc-site` の `pull_request` |
-| ジョブ | **`Docs Build`**: `npm ci` + `npm run build:site` |
+| ジョブ | **`Docs Build`**: スコープ付き `npm ci`（site + library/data）+ `npm run build:site` |
 | 対象外 | アプリの `npm test`、アプリ単体の検証、およびアプリ CI の成否 — **`doc-site` へのマージ判定では無視** |
 
 ### PR の向け先
@@ -63,7 +65,7 @@ Playground が参照するライブラリを、すでに `main` / `release` に�
 | 項目 | ルール |
 |------|--------|
 | トリガ | **`doc-site`** への `push`（通常はマージ後） |
-| ビルド | `npm run build:site` → `site/.output/public` |
+| ビルド | スコープ付き `npm ci`（site + library/data）+ `npm run build:site` → `site/.output/public` |
 | 公開 | **`gh-pages`** ブランチへ orphan force push |
 | 独立 | アプリ CI、`data-v*` / `app-v*` の npm リリース、旧 `site-v*` タグ（廃止）とは無関係 |
 
@@ -75,8 +77,16 @@ Playground が参照するライブラリを、すでに `main` / `release` に�
 |------|--------|
 | トリガ | 週次 cron（月曜 01:30 UTC）+ `workflow_dispatch` |
 | 内容 | 総務省 Excel を取得し `resources/000925835.xlsx` と SHA-256 比較 → `site/public/source-monitor.json` を更新コミット |
+| Install | scripts ワークスペースのみ |
 | 異常時 | `source-monitor` ラベルの Issue 起票／コメント、job failure |
 | 詳細 | [test-spec-66-source-hash.md](./test-spec-66-source-hash.md) / Issue #66 |
+
+## OpenSSF Scorecard（`.github/workflows/scorecard.yml`）
+
+| 項目 | ルール |
+|------|--------|
+| トリガ | 週次 cron（月曜 01:30 UTC）、`branch_protection_rule`、`workflow_dispatch` |
+| 発火しない | `main` への毎回 push（冗長実行削減のため削除） |
 
 ## CD — npm publish（`.github/workflows/publish.yml`）
 
@@ -84,9 +94,10 @@ Playground が参照するライブラリを、すでに `main` / `release` に�
 |------|--------|
 | トリガ | `data-v*` / `app-v*` の GitHub Release **published**、またはタグ指定の `workflow_dispatch` |
 | 祖先チェック | タグのコミットが `origin/release` の祖先であること |
-| 検証スキップ | その SHA に CI success があれば Test/Build 省略。pack + provenance publish は常に実行 |
+| 検証スキップ | その SHA に CI success があれば **Test を省略**。**Build は常に実行**（`dist/` は gitignore） |
 | 履歴なし | Test + Build のあと publish |
-| dispatch | `force_test` で常に Test+Build 可能 |
+| dispatch | `force_test` で常に Test 可能 |
+| Install | アプリ系ワークスペースのみ（site なし） |
 
 `data-v*` / `app-v*` タグは **`release` ブランチから**打つ。`release-on-tag.yml` はこれらのタグのみ自動 Release 作成。
 
@@ -106,8 +117,9 @@ Codecov の **project coverage ≥ 90%**（`codecov.yml` の `target: 90%`）を
 # アプリ / ライブラリ
 ローカル変更 → npm run ci:local（必須）
             → develop / dev-* へ PR
-            → CI Gate → Test ‖ Build → "Test & Build"
-release 上のタグ → Release → Publish（CI 再利用 or 再検証）→ npm
+            → CI Gate → "Test & Build"（単一ジョブ）
+release への push → CI（publish スキップ用の履歴）
+release 上のタグ → Release → Publish（Test 再利用 or 再検証、Build は常時）→ npm
 
 # ドキュメントサイト
 サイト変更 → doc-site へ PR

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -34,19 +34,21 @@ Do not open or update a PR while this gate is failing.
 
 | Item | Rule |
 |------|------|
-| Trigger | `pull_request` whose **base** is `develop` or `dev-*` |
-| Not triggered | Push to arbitrary branches; PRs into `main` / `release` / `doc-site` / other bases |
-| Skip heavy jobs | Same head SHA already has a successful `CI` workflow run |
+| Trigger | `pull_request` whose **base** is `develop` or `dev-*`; `push` to **`main`** or **`release`** |
+| Not triggered | Push to `develop` / arbitrary branches; PRs into `main` / `release` / `doc-site` / other bases |
+| Skip heavy jobs | Same head SHA already has a successful `CI` workflow run; or docs-only change set |
 | Docs-only | Changes limited to `docs/**`, `site/content/**`, `*.md` (and similar) → skip Test/Build on GitHub; local act still runs full jobs by default |
-| Parallelism | `Test` and `Build` jobs run in parallel after `Gate` |
-| Required check name | Aggregate job **`Test & Build`** (stable for branch protection) |
+| Jobs | `Gate` then a single **`Test & Build`** job (`npm ci` once → test → build). Site workspace is not installed |
+| Required check name | **`Test & Build`** (stable for branch protection; job always reports, even when heavy work is skipped) |
+| Why `main` push | Codecov default-branch coverage upload (#121) |
+| Why `release` push | Tag SHAs created from `release` get CI history so publish can skip Test |
 
 ## Docs CI (`.github/workflows/ci-docs.yml`)
 
 | Item | Rule |
 |------|------|
 | Trigger | `pull_request` whose **base** is `doc-site` |
-| Job | **`Docs Build`**: `npm ci` + `npm run build:site` |
+| Job | **`Docs Build`**: scoped `npm ci` (site + library/data) + `npm run build:site` |
 | Out of scope | App `npm test`, app package-only verification, and app CI success/failure — **ignored** for merging into `doc-site` |
 
 ### PR targets
@@ -63,7 +65,7 @@ When the playground needs a newer published library build that already landed on
 | Item | Rule |
 |------|------|
 | Trigger | `push` to **`doc-site`** (typically after merge) |
-| Build | `npm run build:site` → `site/.output/public` |
+| Build | scoped `npm ci` (site + library/data) + `npm run build:site` → `site/.output/public` |
 | Publish | Force-orphan commit to the **`gh-pages`** branch |
 | Independent of | App CI, `data-v*` / `app-v*` npm releases, and legacy `site-v*` tags (removed) |
 
@@ -75,8 +77,16 @@ When the playground needs a newer published library build that already landed on
 |------|------|
 | Trigger | Weekly cron (Monday 01:30 UTC) + `workflow_dispatch` |
 | Action | Fetch MIC Excel, SHA-256 vs `resources/000925835.xlsx`, commit `site/public/source-monitor.json` |
+| Install | scripts workspace only |
 | On anomaly | Open/comment Issue with `source-monitor` label; fail the job |
 | Details | [test-spec-66-source-hash.md](./test-spec-66-source-hash.md) / Issue #66 |
+
+## OpenSSF Scorecard (`.github/workflows/scorecard.yml`)
+
+| Item | Rule |
+|------|------|
+| Trigger | Weekly cron (Monday 01:30 UTC), `branch_protection_rule`, `workflow_dispatch` |
+| Not on | Every `main` push (removed to cut redundant runs) |
 
 ## CD — npm publish (`.github/workflows/publish.yml`)
 
@@ -84,9 +94,10 @@ When the playground needs a newer published library build that already landed on
 |------|------|
 | Trigger | GitHub Release **published** for `data-v*` / `app-v*`, or `workflow_dispatch` with a tag |
 | Ancestry | Tag commit must be an ancestor of `origin/release` (`git merge-base --is-ancestor`) |
-| Verify skip | If that SHA already has CI success → skip Test/Build; always pack + provenance publish |
+| Verify skip | If that SHA already has CI success → skip **Test**; **Build always runs** (`dist/` is gitignored) |
 | No CI history | Run Test + Build, then publish |
-| Dispatch | Optional `force_test` to always run Test+Build |
+| Dispatch | Optional `force_test` to always run Test |
+| Install | App workspaces only (no site) |
 
 Create `data-v*` / `app-v*` tags from the **`release`** branch. `release-on-tag.yml` auto-creates the GitHub Release for those tag patterns only.
 
@@ -106,8 +117,9 @@ Official release is gated on Codecov **project coverage ≥ 90%** (`target: 90%`
 # App / library
 local change → npm run ci:local (must pass)
             → open PR to develop / dev-*
-            → CI Gate → Test ‖ Build → "Test & Build"
-tag on release → Release → Publish (reuse CI or re-verify) → npm
+            → CI Gate → "Test & Build" (single job)
+release push → CI (history for publish skip)
+tag on release → Release → Publish (reuse CI Test or re-verify; always Build) → npm
 
 # Documentation site
 site change → open PR to doc-site


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
CI/CD 調査で洗い出した非効率のうち、効果が大きいものを実装しました。

- **Test / Build を単一ジョブ化**（`npm ci` 1回）し、required check 名 `Test & Build` は維持
- **Scorecard** の `main` 毎回 push をやめ、週次 + 手動 + branch protection のみに
- **develop push の CI を削除**し、代わりに **release push** で publish の CI 再利用を効かせる（main は Codecov 用に残置）
- **Publish** は Test のみスキップ可能に変更し、`dist/` が gitignore のため **Build は常時実行**
- 各 workflow で **必要な workspace だけ `npm ci`**（アプリ / site / scripts）
- `release-on-tag` の不要な `fetch-depth: 0` を削除
- `docs/ci-cd.md` / `docs/ci-cd.ja.md` を追従更新

## Test plan
- [ ] PR / push で CI の check 名が `Test & Build` のまま通る
- [ ] docs-only / SHA 再利用スキップ時も `Test & Build` が成功扱いになり skipped にならない
- [ ] Scorecard が main push で発火しない（週次 / workflow_dispatch は可）
- [ ] release への push で CI が走り、同 SHA の publish が Test をスキップできる
- [ ] app publish で Build が常に走り、tarball に `dist/` が入る

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0748d-1125-7583-8caf-328596a9c37d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0748d-1125-7583-8caf-328596a9c37d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

