### PR TITLE
feat: #94 cachian 移行と purgeCache API

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,9 @@ const client = await createLocalGovClient({
 });
 ```
 
-- When `url` is set, fetched files are decompressed/decoded and cached in localStorage by default (key = file URL). The cached value is a minified `JSON.stringify` of the decoded object — **separate from on-wire `.bin.br` (Brotli)**; raw bytes are never stored in localStorage
+- When `url` is set, fetched files are decompressed/decoded and cached in localStorage by default via `@b4moss/cachian` (keys prefixed with `jp-local-gov-id:`). The cached value is a minified `JSON.stringify` of the decoded object — **separate from on-wire `.bin.br` (Brotli)**; raw bytes are never stored in localStorage
 - Disable with `cache: false`; set TTL via `cacheTtlSeconds` (seconds; default 1 year = `31536000`)
+- Clear with `await client.purgeCache({ all: true })` (or `{ keys: [...] }`, etc.)
 - Exception: municipality data and JLIX (`search-ngrams/**`) loaded by **nationwide** string search stay in memory only (not written to localStorage)
 - Environments without localStorage (e.g. Node) skip caching
 - String search normalizes hiragana / fullwidth kana to halfwidth kana (`matchField` default: `"both"`). After normalize: length &lt; 2 → empty; length 2 → hot 2-gram only; length ≥ 3 → merge 2-gram and 3-gram

--- a/README_ja.md
+++ b/README_ja.md
@@ -61,8 +61,9 @@ const client = await createLocalGovClient({
 });
 ```
 
-- `url` 指定時、取得したファイルを展開・デコードして localStorage にキャッシュします（既定 ON。キーは各ファイルの URL）。保存する文字列はデコード後オブジェクトの `JSON.stringify`（minify。空白なし）。**転送ペイロードの `.bin.br`（Brotli）とは別**で、localStorage に生バイトは置きません
+- `url` 指定時、取得したファイルを展開・デコードして localStorage にキャッシュします（既定 ON。`@b4moss/cachian`、キーは `jp-local-gov-id:` プレフィックス）。保存する文字列はデコード後オブジェクトの `JSON.stringify`（minify。空白なし）。**転送ペイロードの `.bin.br`（Brotli）とは別**で、localStorage に生バイトは置きません
 - `cache: false` で無効化、`cacheTtlSeconds` で有効期限を秒単位で指定（既定 1 年 = `31536000`）
+- `await client.purgeCache({ all: true })` などで明示削除
 - 例外: **全国対象**の文字列検索で取得した県別データ、および JLIX（`search-ngrams/**`）は localStorage に書かず、メモリのみ保持します
 - localStorage が無い環境（Node 等）ではキャッシュをスキップします
 - 文字列検索はひらがな／全角カナを半角カナへ正規化します（`matchField` 既定: `"both"`）。正規化後長が 2 未満は空、2 はホット 2-gram のみ、3 以上は 2-gram と 3-gram をマージ

--- a/docs/logics.md
+++ b/docs/logics.md
@@ -70,7 +70,10 @@
 
 - `cache` 既定 `true`。`false` で localStorage 読み書きなし
 - `cacheTtlSeconds` 既定 `31536000`（1 年）。単位は秒
-- `data` モードではキャッシュしない
+- 実装は `@b4moss/cachian`（localStorage + get/set/purge）。物理キーは `jp-local-gov-id:` プレフィックス付き
+- 利用者は `LocalGovClient.purgeCache(options)` で明示削除できる（`{ all: true }` / `{ keys }` / 時間条件）。内部経路は自動 purge しない
+- TTL 切れの高度な振る舞いは cachian 側に委譲（本パッケージでは自前の期限切れ削除を持たない）
+- `data` モードではキャッシュしない（`purgeCache` は no-op）
 
 全国市区町村検索はハイブリッド JLIX（ホット団体は **2-gram 地域ファイル**、それ以外は **3-gram を 3 シャード**）で候補 `muniCode` を絞り、該当県 `.bin.br` のみ並列取得（同時 6、取得後 Brotli 展開）。索引ファイル自体は **concurrency=3・開始 100ms ずらし**でロード。正規化後長が 2 なら 2-gram のみ、3 以上なら両索引をマージ（2-gram ヒットでも 3-gram は省略しない）。`target: "prefectures"` および都道府県指定時は索引を使わない。配信ペイロードは npm / CDN とも **Brotli（`.bin.br`）**（#74）。
 
@@ -83,8 +86,9 @@
 #### `createLocalGovClient(options)` → `Promise<LocalGovClient>`
 
 - `options`: `{ data }` または `{ url }`（どちらか必須、両方不可）
-- `cache?: boolean`（既定 `true`）— `url` モードの localStorage キャッシュ
+- `cache?: boolean`（既定 `true`）— `url` モードの localStorage キャッシュ（`@b4moss/cachian`）
 - `cacheTtlSeconds?: number`（既定 `31536000`）— TTL（秒）。`url` かつ `cache: true` のとき有効
+- `LocalGovClient.purgeCache(options: CachePurgeOptions): Promise<void>` — URL キャッシュの明示削除
 - index + 都道府県を読み込み、スキーマ検証してクライアントを返す
 - 市区町村はまだ読まない
 
@@ -163,9 +167,11 @@
 | `isPrefecture` / `isMunicipality` | fn | union 判別 |
 | `prefectureOrgCode` | fn | 都道府県エンティティ → 2 桁組織キー |
 
-型: `Prefecture`, `Municipality`, `LocalGov`, `LocalGovClient`, `CreateLocalGovOptions`, `CreateLocalGovCacheOptions`, `SearchOptions`, `SearchTarget`, `MatchField`, `DesignatedCityMode`, `ListMunicipalitiesOptions`, `LocalGovDataset`, `LocalGovIndexFile`, `LocalGovPrefecturesFile`, `LocalGovMunicipalitiesFile`, `LocalGovDataFile`（deprecated）
+型: `Prefecture`, `Municipality`, `LocalGov`, `LocalGovClient`, `CreateLocalGovOptions`, `CreateLocalGovCacheOptions`, `CachePurgeOptions`, `SearchOptions`, `SearchTarget`, `MatchField`, `DesignatedCityMode`, `ListMunicipalitiesOptions`, `LocalGovDataset`, `LocalGovIndexFile`, `LocalGovPrefecturesFile`, `LocalGovMunicipalitiesFile`, `LocalGovDataFile`（deprecated）
 
-定数: `DEFAULT_CACHE_TTL_SECONDS`（`31536000`）、`CACHE_TTL_MS`（deprecated 互換）、`LOCAL_GOV_SCHEMA_VERSION`、`MUNICIPALITY_FETCH_CONCURRENCY`
+定数: `DEFAULT_CACHE_TTL_SECONDS`（`31536000`）、`CACHE_TTL_MS`（deprecated 互換）、`CACHE_KEY_PREFIX`（`jp-local-gov-id:`）、`LOCAL_GOV_SCHEMA_VERSION`、`MUNICIPALITY_FETCH_CONCURRENCY`
+
+型: `CachePurgeOptions`（`@b4moss/cachian` から re-export）
 
 旧名（`createLocalGov`, `getPrefectureCode`, `getMunicipalitiesByPrefecture`, `search`, `getCodeByName`）に互換エイリアスは置かない。
 

--- a/docs/main.md
+++ b/docs/main.md
@@ -136,6 +136,8 @@ const client = await createLocalGovClient({
   - 保存する文字列は `JSON.stringify`（**minify**。空白なし）
   - **転送ペイロードの Brotli（`.bin.br`）とは別レイヤ**。生バイトを localStorage に保存することはない
 - `cache?: boolean`（既定 `true`）、`cacheTtlSeconds?: number`（既定 `31536000`）
+- キャッシュは `@b4moss/cachian`（prefix `jp-local-gov-id:`）。`purgeCache` で明示削除
+- キャッシュ実装は `@b4moss/cachian`（キー prefix `jp-local-gov-id:`）。`purgeCache` で明示削除
 - 例外: **全国対象の文字列検索**で取得した県別データと JLIX は localStorage に書かず、**メモリのみ**
 - `data` を直接渡した場合はキャッシュしない
 - **キャッシュキーは版付き URL そのもの**
@@ -254,6 +256,8 @@ type LocalGovClient = {
   searchByText(text: string, options?: SearchOptions): Promise<LocalGov[]>
   /** 正式名称 → 地方公共団体コード（6 桁）。都道府県ヒット時も 6 桁 */
   getLocalGovCodeByName(name: string, options?: SearchOptions): Promise<string | null>
+  /** URL モードの localStorage キャッシュを明示削除（`@b4moss/cachian` CachePurgeOptions） */
+  purgeCache(options: CachePurgeOptions): Promise<void>
 }
 ```
 

--- a/docs/test-spec-94-cachian-purge.md
+++ b/docs/test-spec-94-cachian-purge.md
@@ -1,0 +1,231 @@
+# テスト仕様書: キャッシュ API の cachian 外出しと purgeCache（#94）
+
+対象マイルストーン: `v1.1.0`  
+関連: Issue #94 / 作業ブランチ `cursor/cachian-cache-purge-6db9` / 統合先 `dev-v1.1.0`  
+想定実装:
+
+- 依存: `@b4moss/cachian@0.4.0`
+- 取り込み範囲: `localStorageDriver` + `get` / `set` / `purge` のみ
+- 内部配線: [`packages/jp-local-gov-id/src/cache.ts`](../packages/jp-local-gov-id/src/cache.ts) / [`create.ts`](../packages/jp-local-gov-id/src/create.ts) / [`api.ts`](../packages/jp-local-gov-id/src/api.ts) / [`types.ts`](../packages/jp-local-gov-id/src/types.ts)
+- 公開: `LocalGovClient.purgeCache(options)`、`CachePurgeOptions` の型 re-export
+
+## 1. 目的
+
+自前 localStorage キャッシュ実装を **`@b4moss/cachian` に置き換え**、利用者が明示的にキャッシュを消せる **`purgeCache` API** を固定する。
+
+- url 経路の読み書きは従来どおり **get / set のみ**（自動 purge なし）
+- IndexedDB および `remove` / `clear` / `update` / `upsert` / `has` は **取り込まない**
+- 自前の TTL 切れ判定・削除は **破棄**する。TTL 切れの高度な振る舞いは cachian 側の今後に委ね、本パッケージでは保証しない（破壊的変更として許容）
+- `purge({ all: true })` がアプリ全体の localStorage を消さないよう、物理キーに **`keyPrefix`** を付ける
+
+## 2. 用語
+
+| 用語 | 意味 |
+|------|------|
+| cachian | `@b4moss/cachian@0.4.0`。browser cache helper |
+| 論理キー | キャッシュの論理キー。現行どおり **絶対 URL 文字列**（index / prefectures / 市区町村ファイル URL） |
+| 物理キー | localStorage 上の実キー。`keyPrefix + 論理キー` |
+| keyPrefix | 固定値 `jp-local-gov-id:` |
+| cache インスタンス | `createLocalGovClient`（url モード）内で作る `createCache(...)` の1インスタンス。`fetchAndCache` と `purgeCache` が共有 |
+| `purgeCache` | `LocalGovClient` のメソッド。引数は cachian の `CachePurgeOptions` |
+| minify キャッシュ | デコード後オブジェクトを JSON 文字列として保存する現行意味（Brotli 生バイトは保存しない）。#73 の定義を踏襲 |
+
+対象境界:
+
+| 含む | 含まない |
+|------|----------|
+| `@b4moss/jp-local-gov-id` の url モード localStorage キャッシュ | メモリ上の検索パーティションキャッシュ（JLIX） |
+| `LocalGovClient.purgeCache` | 独立関数としての purge export |
+| `cache` / `cacheTtlSeconds` オプションの継続 | IndexedDB ドライバ |
+| | cachian 本体の TTL 切れ実装の追加・改修 |
+
+## 3. 依存・配線ケース（TC-D）
+
+実装先の目安: `package.json` 契約確認、または薄いユニット / ビルドスモーク。
+
+### TC-D01: 依存バージョン
+
+- **期待**: `packages/jp-local-gov-id` の `dependencies` に `"@b4moss/cachian": "0.4.0"` がある
+- **期待**: ルート `package-lock.json` が当該バージョンに解決する
+
+### TC-D02: 取り込み範囲
+
+- **期待**: ソースが import するのは次に限る
+  - `@b4moss/cachian`（`createCache` および必要な型）
+  - `@b4moss/cachian/drivers/localStorage`
+  - `@b4moss/cachian/methods/get`
+  - `@b4moss/cachian/methods/set`
+  - `@b4moss/cachian/methods/purge`
+- **期待**: `drivers/indexedDB` および他 methods サブパスを import しない
+
+### TC-D03: クライアント単位のインスタンス共有
+
+- **前提**: url モードで `createLocalGovClient` を実行
+- **期待**: 同一クライアントの fetch 経路（get/set）と `purgeCache` が同じ cache インスタンス（同じ prefix / enabled / 既定 TTL）を使う
+- **期待**: 別クライアントを別オプション（例: `cache: false` と `cache: true`）で作った場合、互いの enabled 状態を汚染しない
+
+### TC-D04: data モードではキャッシュしない
+
+- **前提**: `{ data }` でクライアント作成
+- **期待**: localStorage への書き込みが起きない
+- **期待**: `purgeCache(...)` は例外を投げず no-op（Promise が resolve）
+
+## 4. get / set ケース（TC-G）— 現行経路
+
+実装先の目安: `cache.test.ts` / `api.test.ts`（url + cache）。
+
+### TC-G01: ミス後にフェッチして set
+
+- **前提**: `cache: true`、localStorage 利用可、対象 URL のキャッシュなし
+- **操作**: url モードでクライアント作成（または市町村ファイルを読む API を呼ぶ）
+- **期待**: ネットワーク（またはフィクスチャ fetch）が走る
+- **期待**: 物理キー `jp-local-gov-id:` + 絶対 URL にエントリが書かれる
+- **期待**: エントリはデコード後オブジェクト相当（minify JSON）。`.bin.br` 生バイトではない
+
+### TC-G02: ヒット時は再フェッチしない
+
+- **前提**: TC-G01 相当でキャッシュ済み
+- **操作**: 同じ url で再度 `createLocalGovClient`（または同一ファイルを再読込）
+- **期待**: 当該 URL の fetch 回数が増えない（キャッシュから復元）
+- **期待**: 公開 API の結果はスキーマ検証後の正当なデータ
+
+### TC-G03: `cache: false` で読み書きしない
+
+- **前提**: `cache: false`
+- **操作**: クライアント作成 → 再度作成
+- **期待**: localStorage に本パッケージ prefix のキーが増えない
+- **期待**: 毎回 fetch する
+
+### TC-G04: `cacheTtlSeconds` を set に渡す
+
+- **前提**: `cacheTtlSeconds: 60` など有限の非負値
+- **操作**: url モードで書き込み発生
+- **期待**: 保存エントリの `expiresAt` が「書き込み時刻 + TTL 秒」付近になる（cachian の set 契約）
+- **期待**: 不正値（負数・非有限）は作成時に TypeError（現行メッセージ意味を維持。`cacheTtlSeconds` を含む）
+
+### TC-G05: 全国検索・JLIX は localStorage しない
+
+- **前提**: #63 / #73 の既存契約
+- **期待**: 全国市区町村検索で読む県 `.bin.br`（persist しない経路）および JLIX（`search-ngrams/**`）は localStorage に書かない
+- **期待**: 本変更でこの契約を壊さない
+
+### TC-G06: 環境不可時は静かな miss / no-op
+
+- **前提**: `localStorage` 未定義、またはアクセスが throw
+- **操作**: get 相当（クライアント作成）/ set 相当
+- **期待**: 例外で落とさない（cachian の `CachianEnvironmentError` を利用者に漏らさない）
+- **期待**: キャッシュなしとしてフェッチ経路へ進める
+
+### TC-G07: 書き込み失敗（quota 等）を握りつぶす
+
+- **前提**: `setItem` が throw する Storage
+- **操作**: キャッシュ書き込み発生
+- **期待**: 利用者向け例外にしない（現行踏襲）
+
+## 5. キー・エントリ形ケース（TC-K）
+
+### TC-K01: keyPrefix
+
+- **期待**: 物理キーは必ず `jp-local-gov-id:` で始まる
+- **期待**: 論理キー（API / purge の `keys`）は **prefix なしの絶対 URL**
+- **期待**: prefix なしの旧キー（破壊的変更前の URL 直置き）は読まれない（ミス扱い・再フェッチでよい）
+
+### TC-K02: エントリ形
+
+- **期待**: localStorage 上の値は cachian エントリ（少なくとも `expiresAt` と `data`）
+- **期待**: 新規 `set` では `createdAt` が付く（cachian 0.4.0 契約）
+- **期待**: 不正 JSON / エントリ形でない値は miss として扱われ、可能なら当該物理キーを除去（cachian / ドライバ任せでよい）
+
+### TC-K03: 自前 TTL 切れテストを置かない
+
+- **期待**: 本パッケージのテストに「時間を進めて get が null になりキーが消える」といった **自前 TTL 切れの仕様固定**を新規・継続で置かない
+- **理由**: TTL 切れ処理は cachian 側の今後に委ねる方針のため。本パッケージは set 時に TTL を渡すことと、オプション検証のみを固定する
+- **許容**: cachian が get 時に期限切れを miss にする実装であっても、それを本リポジトリの受け入れ条件としては必須にしない（将来変更に追従）
+
+## 6. purgeCache ケース（TC-P）
+
+実装先の目安: `api.test.ts`（クライアントメソッド）。型は `CachePurgeOptions`。
+
+### TC-P01: 公開面
+
+- **期待**: `LocalGovClient` に `purgeCache(options: CachePurgeOptions): Promise<void>` がある
+- **期待**: パッケージの公開型として `CachePurgeOptions` を利用者が import できる（cachian からの re-export 可）
+- **期待**: 独立関数（例: `purgeLocalGovCache`）は **export しない**
+
+### TC-P02: `purgeCache({ all: true })`
+
+- **前提**: url モード、`cache: true`、複数 URL がキャッシュ済み。加えて prefix 外の localStorage キーが存在する
+- **操作**: `await client.purgeCache({ all: true })`
+- **期待**: `jp-local-gov-id:` 配下のキーがすべて消える
+- **期待**: prefix 外のキーは残る（他ライブラリ・アプリデータを消さない）
+
+### TC-P03: `purgeCache({ keys })`
+
+- **前提**: URL A / B がキャッシュ済み
+- **操作**: `await client.purgeCache({ keys: [A] })`（A は論理キー＝絶対 URL）
+- **期待**: A のみ消え、B は残る
+- **期待**: その後 A を要すると再フェッチ、B はヒットし得る
+
+### TC-P04: `olderThan` / `createdBefore` / `createdAfter`
+
+- **前提**: 新規 set 済みエントリ（`createdAt` あり）
+- **操作**: cachian が受け付ける時間条件で `purgeCache` を呼ぶ
+- **期待**: 条件に合うエントリだけ削除される（詳細閾値は cachian 契約に委譲。本パッケージは委譲呼び出しが届くことを固定）
+- **期待**: `olderThan` と `createdBefore` / `createdAfter` の混在は TypeError（cachian と同じ）
+
+### TC-P05: `cache: false` のクライアント
+
+- **前提**: `cache: false` の url クライアント（または同等の enabled=false インスタンス）
+- **操作**: `purgeCache({ all: true })` など
+- **期待**: 例外なしで no-op。既存の他キー（別クライアントが書いたもの含む）を誤って消さない
+
+### TC-P06: 内部経路は purge を自動呼び出ししない
+
+- **操作**: 通常の create / list / getByCode / search のみ
+- **期待**: `purge` が副作用として走らない（キャッシュが勝手に全消しされない）
+
+## 7. 回帰・公開契約ケース（TC-R）
+
+### TC-R01: 既存公開オプション
+
+- **期待**: `cache?: boolean`（既定 `true`）、`cacheTtlSeconds?: number`（既定 `31536000`）が残る
+- **期待**: `DEFAULT_CACHE_TTL_SECONDS` / deprecated `CACHE_TTL_MS` の export が残る
+
+### TC-R02: メソッド一覧への追加のみ
+
+- **期待**: 既存 `LocalGovClient` メソッドの同期/非同期・戻り値意味を変えない
+- **期待**: 追加は `purgeCache` のみ（本 Issue 範囲）
+
+### TC-R03: ドキュメント記載
+
+- **期待**: 次に依存・prefix・`purgeCache`・破壊的変更（旧キー無効、TTL 切れは cachian 委譲）が書かれる
+  - `packages/jp-local-gov-id/README.md` / `README_ja.md`
+  - `site/content/*/api.md`（および必要なら usage）
+  - `docs/logics.md` / `docs/main.md`
+
+## 8. 非対象（明示）
+
+- cachian リポジトリ側への TTL 切れ機能追加
+- IndexedDB バックエンド
+- `remove` / `clear` を本パッケージ公開 API として出すこと（必要なら `purge` の options で表現）
+- キャッシュ値の追加圧縮（Brotli 生保存など）。minify JSON の意味は #73 のまま
+- SSR 向けの永続キャッシュ代替ストレージ
+
+## 9. 破壊的変更チェックリスト（受け入れ時に確認）
+
+| 項目 | 受け入れ |
+|------|----------|
+| 旧物理キー（prefix なし URL）が読めない | 再フェッチされれば合格 |
+| 自前 TTL 切れ TC の削除または無効化 | 本仕様 TC-K03 に合致すれば合格 |
+| エントリに `createdAt` が付く | cachian 形式で合格 |
+| `purgeCache` 追加 | TC-P を満たせば合格 |
+
+## 10. 実装マッピング（目安）
+
+| ID | 主な実装 / テストファイル |
+|----|---------------------------|
+| TC-D* | `package.json`、`create.ts`、`cache.ts` |
+| TC-G* | `cache.test.ts`、`api.test.ts` |
+| TC-K* | `cache.test.ts` |
+| TC-P* | `api.test.ts`、`types.ts`、`index.ts` |
+| TC-R* | `index.ts`、README、site、`docs/logics.md` |

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,15 @@
         "@types/json-schema": "^7.0.15"
       }
     },
+    "node_modules/@b4moss/cachian": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@b4moss/cachian/-/cachian-0.4.0.tgz",
+      "integrity": "sha512-KgdxDb2PhVE0nvaJO2peTBwQ/PGtsaBIuiU/0sh0qRCdvEM24t2qWadAxEAJyr1Pw5MuN/7G5AgD0EGiEXeU1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=24"
+      }
+    },
     "node_modules/@b4moss/jp-local-gov-id": {
       "resolved": "packages/jp-local-gov-id",
       "link": true
@@ -17409,6 +17418,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@b4moss/cachian": "0.4.0",
         "brotli-wasm": "^3.0.1"
       },
       "devDependencies": {

--- a/packages/jp-local-gov-id/README.md
+++ b/packages/jp-local-gov-id/README.md
@@ -50,8 +50,9 @@ const client = await createLocalGovClient({
 });
 ```
 
-- When `url` is set, fetched files are decompressed/decoded and cached in localStorage by default. The cached string is a minified `JSON.stringify` of the decoded object — **separate from on-wire `.bin.br` (Brotli)**; raw bytes are never stored in localStorage
+- When `url` is set, fetched files are decompressed/decoded and cached in localStorage by default via [`@b4moss/cachian`](https://www.npmjs.com/package/@b4moss/cachian) (localStorage + get/set/purge). Keys use the prefix `jp-local-gov-id:`. The cached string is a minified `JSON.stringify` of the decoded object — **separate from on-wire `.bin.br` (Brotli)**; raw bytes are never stored in localStorage
 - Disable with `cache: false`; set TTL via `cacheTtlSeconds` (seconds; default 1 year = `31536000`)
+- Clear cache explicitly with `await client.purgeCache({ all: true })` or `{ keys: [...] }` (and other `@b4moss/cachian` purge options). No-op for `data` mode / `cache: false`
 - Exception: municipality data and JLIX loaded by **nationwide** string search stay in memory only
 - After normalize: length &lt; 2 → empty; length 2 → hot 2-gram only; length ≥ 3 → merge 2-gram and 3-gram
 - Schema mismatches or invalid data raise `LocalGovSchemaError`; missing/ambiguous results return `null` / `[]`

--- a/packages/jp-local-gov-id/README_ja.md
+++ b/packages/jp-local-gov-id/README_ja.md
@@ -50,8 +50,9 @@ const client = await createLocalGovClient({
 });
 ```
 
-- `url` 指定時、取得したファイルを展開・デコードして localStorage にキャッシュします（既定 ON）。保存するのはデコード後オブジェクトの minify JSON。**転送の `.bin.br`（Brotli）とは別**で、localStorage に生バイトは置きません
+- `url` 指定時、取得したファイルを展開・デコードして localStorage にキャッシュします（既定 ON）。実装は [`@b4moss/cachian`](https://www.npmjs.com/package/@b4moss/cachian)（localStorage + get/set/purge）。キーは `jp-local-gov-id:` プレフィックス付き。保存するのはデコード後オブジェクトの minify JSON。**転送の `.bin.br`（Brotli）とは別**で、localStorage に生バイトは置きません
 - `cache: false` で無効化、`cacheTtlSeconds` で TTL（秒。既定 1 年）
+- 明示的な削除は `await client.purgeCache({ all: true })` または `{ keys: [...] }`（他オプションは cachian に準拠）。`data` モード / `cache: false` では no-op
 - 例外: **全国対象**の文字列検索で取得した県別データと JLIX はメモリのみ
 - 正規化後長が 2 未満 → 空 / 2 → ホット 2-gram のみ / 3 以上 → 2-gram と 3-gram をマージ
 - スキーマ不一致・不正データ → `LocalGovSchemaError`。見つからない・衝突 → `null` / `[]`

--- a/packages/jp-local-gov-id/package.json
+++ b/packages/jp-local-gov-id/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@b4moss/jp-local-gov-id",
   "version": "1.0.0",
-  "description": "\u5168\u56fd\u5730\u65b9\u516c\u5171\u56e3\u4f53\u30b3\u30fc\u30c9\u30d8\u30eb\u30d1 \u2014 \u65e5\u672c\u306e\u5168\u56fd\u5730\u65b9\u516c\u5171\u56e3\u4f53\u30b3\u30fc\u30c9\u3092\u6271\u3046 npm \u30d1\u30c3\u30b1\u30fc\u30b8",
+  "description": "全国地方公共団体コードヘルパ — 日本の全国地方公共団体コードを扱う npm パッケージ",
   "type": "module",
   "main": "./dist/jp-local-gov-id.cjs",
   "module": "./dist/jp-local-gov-id.js",
@@ -54,6 +54,7 @@
     "vitest": "^4.1.10"
   },
   "dependencies": {
+    "@b4moss/cachian": "0.4.0",
     "brotli-wasm": "^3.0.1"
   }
 }

--- a/packages/jp-local-gov-id/src/api.test.ts
+++ b/packages/jp-local-gov-id/src/api.test.ts
@@ -4,7 +4,7 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import dataset from "@b4moss/jp-local-gov-id-data";
 import { createLocalGovClient } from "./create";
-import { CACHE_TTL_MS } from "./cache";
+import { CACHE_KEY_PREFIX, CACHE_TTL_MS } from "./cache";
 import { MUNICIPALITY_FETCH_CONCURRENCY } from "./pool";
 import { LocalGovSchemaError } from "./schema";
 import type { LocalGovClient, LocalGovIndexFile } from "./types";
@@ -515,16 +515,31 @@ describe("createLocalGovClient url + cache + lazy load", () => {
   });
 
   function stubLocalStorage() {
-    const localStorage = {
-      getItem: (key: string) => store.get(key) ?? null,
-      setItem: (key: string, value: string) => {
-        store.set(key, value);
+    const localStorage: Storage = {
+      get length() {
+        return store.size;
       },
-      removeItem: (key: string) => {
+      clear() {
+        store.clear();
+      },
+      getItem(key: string) {
+        return store.get(key) ?? null;
+      },
+      key(index: number) {
+        return [...store.keys()][index] ?? null;
+      },
+      removeItem(key: string) {
         store.delete(key);
+      },
+      setItem(key: string, value: string) {
+        store.set(key, value);
       },
     };
     vi.stubGlobal("localStorage", localStorage);
+  }
+
+  function physicalKey(url: string): string {
+    return `${CACHE_KEY_PREFIX}${url}`;
   }
 
   function stubFetch(files: Map<string, unknown>) {
@@ -578,9 +593,9 @@ describe("createLocalGovClient url + cache + lazy load", () => {
     expect(c.listPrefectures()).toHaveLength(47);
     // index + prefectures only
     expect(fetchMock).toHaveBeenCalledTimes(2);
-    expect(store.has(indexUrl)).toBe(true);
+    expect(store.has(physicalKey(indexUrl))).toBe(true);
 
-    const cached = JSON.parse(store.get(indexUrl)!);
+    const cached = JSON.parse(store.get(physicalKey(indexUrl))!);
     expect(cached.expiresAt).toBeGreaterThan(Date.now());
     expect(cached.expiresAt).toBeLessThanOrEqual(
       Date.now() + CACHE_TTL_MS + 1000,
@@ -674,10 +689,12 @@ describe("createLocalGovClient url + cache + lazy load", () => {
       expect(key).not.toMatch(/\/prefectures\/\d{2}\.bin(\.br)?$/);
       expect(key).not.toMatch(/search-ngrams\//);
     }
-    expect(store.has(indexUrl)).toBe(true);
+    expect(store.has(physicalKey(indexUrl))).toBe(true);
     expect(
       store.has(
-        "https://cdn.example.com/jp-local-gov-id-data/0.2.0/prefectures.bin.br",
+        physicalKey(
+          "https://cdn.example.com/jp-local-gov-id-data/0.2.0/prefectures.bin.br",
+        ),
       ),
     ).toBe(true);
 
@@ -695,7 +712,9 @@ describe("createLocalGovClient url + cache + lazy load", () => {
     await c.getByCode("131016");
     expect(
       store.has(
-        "https://cdn.example.com/jp-local-gov-id-data/0.2.0/prefectures/13.bin.br",
+        physicalKey(
+          "https://cdn.example.com/jp-local-gov-id-data/0.2.0/prefectures/13.bin.br",
+        ),
       ),
     ).toBe(true);
     expect(fetchMock).toHaveBeenCalledTimes(3);
@@ -709,7 +728,9 @@ describe("createLocalGovClient url + cache + lazy load", () => {
     await c.searchByText("中央", { prefecture: "01", target: "cities" });
     expect(
       store.has(
-        "https://cdn.example.com/jp-local-gov-id-data/0.2.0/prefectures/01.bin.br",
+        physicalKey(
+          "https://cdn.example.com/jp-local-gov-id-data/0.2.0/prefectures/01.bin.br",
+        ),
       ),
     ).toBe(true);
     expect(fetchMock).toHaveBeenCalledTimes(3);
@@ -738,7 +759,7 @@ describe("createLocalGovClient url + cache + lazy load", () => {
     );
 
     await expect(createLocalGovClient({ url: indexUrl })).rejects.toThrow(/404/);
-    expect(store.has(indexUrl)).toBe(false);
+    expect(store.has(physicalKey(indexUrl))).toBe(false);
   });
 
   it("treats invalid JSON as schema error", async () => {
@@ -802,7 +823,7 @@ describe("createLocalGovClient url + cache + lazy load", () => {
 
     await createLocalGovClient({ url: indexUrl, cacheTtlSeconds: 60 });
 
-    const cached = JSON.parse(store.get(indexUrl)!);
+    const cached = JSON.parse(store.get(physicalKey(indexUrl))!);
     expect(cached.expiresAt).toBeGreaterThanOrEqual(before + 60_000);
     expect(cached.expiresAt).toBeLessThanOrEqual(Date.now() + 60_000 + 1000);
   });
@@ -814,6 +835,52 @@ describe("createLocalGovClient url + cache + lazy load", () => {
     await expect(
       createLocalGovClient({ url: indexUrl, cacheTtlSeconds: -1 }),
     ).rejects.toThrow(/cacheTtlSeconds/);
+  });
+
+  it("purgeCache({ all: true }) clears prefixed entries only", async () => {
+    stubLocalStorage();
+    stubFetch(fileMap());
+    store.set("other:keep", "1");
+
+    const c = await createLocalGovClient({ url: indexUrl });
+    expect(store.has(physicalKey(indexUrl))).toBe(true);
+
+    await c.purgeCache({ all: true });
+    expect(store.has(physicalKey(indexUrl))).toBe(false);
+    expect(store.get("other:keep")).toBe("1");
+  });
+
+  it("purgeCache({ keys }) clears listed logical URLs", async () => {
+    stubLocalStorage();
+    stubFetch(fileMap());
+    const c = await createLocalGovClient({ url: indexUrl });
+    const prefsUrl =
+      "https://cdn.example.com/jp-local-gov-id-data/0.2.0/prefectures.bin.br";
+    expect(store.has(physicalKey(indexUrl))).toBe(true);
+    expect(store.has(physicalKey(prefsUrl))).toBe(true);
+
+    await c.purgeCache({ keys: [indexUrl] });
+    expect(store.has(physicalKey(indexUrl))).toBe(false);
+    expect(store.has(physicalKey(prefsUrl))).toBe(true);
+  });
+
+  it("purgeCache is a no-op when cache is false", async () => {
+    stubLocalStorage();
+    stubFetch(fileMap());
+    await createLocalGovClient({ url: indexUrl });
+    expect(store.has(physicalKey(indexUrl))).toBe(true);
+
+    const noCache = await createLocalGovClient({ url: indexUrl, cache: false });
+    await noCache.purgeCache({ all: true });
+    expect(store.has(physicalKey(indexUrl))).toBe(true);
+  });
+
+  it("purgeCache is a no-op for data mode clients", async () => {
+    stubLocalStorage();
+    const c = await createLocalGovClient({ data: dataset });
+    store.set(`${CACHE_KEY_PREFIX}https://x/index.json`, "x");
+    await expect(c.purgeCache({ all: true })).resolves.toBeUndefined();
+    expect(store.get(`${CACHE_KEY_PREFIX}https://x/index.json`)).toBe("x");
   });
 
   it("resolves path-only index URLs via location", async () => {

--- a/packages/jp-local-gov-id/src/api.ts
+++ b/packages/jp-local-gov-id/src/api.ts
@@ -12,6 +12,7 @@ import {
   type SearchIndexHit,
 } from "./searchIndex";
 import type { LocalGovStore } from "./store";
+import type { LocalGovCache } from "./cache";
 import type {
   ListMunicipalitiesOptions,
   LocalGov,
@@ -180,8 +181,18 @@ async function collectNationwideViaIndex(
   return sortSearchHits([...prefs, ...filteredMunis]);
 }
 
+export type BuildLocalGovClientOptions = {
+  /** Shared URL-mode cache; omit / no-op for `data` mode. */
+  cache?: LocalGovCache;
+};
+
 /** Build a client from an in-memory store (internal). */
-export function buildLocalGovClient(store: LocalGovStore): LocalGovClient {
+export function buildLocalGovClient(
+  store: LocalGovStore,
+  options?: BuildLocalGovClientOptions,
+): LocalGovClient {
+  const cache = options?.cache;
+
   return {
     listPrefectures(): Prefecture[] {
       return [...store.prefectures];
@@ -346,6 +357,11 @@ export function buildLocalGovClient(store: LocalGovStore): LocalGovClient {
 
       if (matches.length !== 1) return null;
       return matches[0]?.code ?? null;
+    },
+
+    async purgeCache(purgeOptions) {
+      if (!cache) return;
+      await cache.purge(purgeOptions);
     },
   };
 }

--- a/packages/jp-local-gov-id/src/cache.test.ts
+++ b/packages/jp-local-gov-id/src/cache.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { getCachedData, setCachedData } from "./cache";
+import {
+  CACHE_KEY_PREFIX,
+  createLocalGovCache,
+} from "./cache";
 
 function memoryStorage(): Storage {
   const map = new Map<string, string>();
@@ -25,66 +28,103 @@ function memoryStorage(): Storage {
   };
 }
 
-describe("cache helpers", () => {
+describe("createLocalGovCache (cachian)", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
-    vi.useRealTimers();
   });
 
-  it("returns null when disabled or localStorage is unavailable", () => {
-    expect(getCachedData("https://x/index.json", { enabled: false })).toBeNull();
+  it("returns null when disabled or localStorage is unavailable", async () => {
+    const disabled = createLocalGovCache({ enabled: false });
+    expect(await disabled.get("https://x/index.json")).toBeNull();
+
     Reflect.deleteProperty(globalThis, "localStorage");
-    expect(getCachedData("https://x/index.json")).toBeNull();
-    setCachedData("https://x/index.json", { ok: true });
+    const unavailable = createLocalGovCache();
+    expect(await unavailable.get("https://x/index.json")).toBeNull();
+    await expect(
+      unavailable.set("https://x/index.json", { ok: true }),
+    ).resolves.toBeUndefined();
+    await expect(unavailable.purge({ all: true })).resolves.toBeUndefined();
   });
 
-  it("round-trips values and respects ttl", () => {
+  it("round-trips values under the key prefix", async () => {
     const storage = memoryStorage();
     vi.stubGlobal("localStorage", storage);
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
 
-    setCachedData("https://x/index.json", { v: 1 }, { ttlSeconds: 10 });
-    expect(getCachedData("https://x/index.json")).toEqual({ v: 1 });
+    const cache = createLocalGovCache({ ttlSeconds: 60 });
+    await cache.set("https://x/index.json", { v: 1 });
+    expect(await cache.get("https://x/index.json")).toEqual({ v: 1 });
 
-    vi.setSystemTime(new Date("2026-01-01T00:00:11Z"));
-    expect(getCachedData("https://x/index.json")).toBeNull();
+    const physicalKey = `${CACHE_KEY_PREFIX}https://x/index.json`;
+    expect(storage.getItem(physicalKey)).toBeTruthy();
+    const entry = JSON.parse(storage.getItem(physicalKey)!);
+    expect(entry.data).toEqual({ v: 1 });
+    expect(typeof entry.expiresAt).toBe("number");
+    expect(typeof entry.createdAt).toBe("number");
+    // Logical URL key must not be written without prefix.
     expect(storage.getItem("https://x/index.json")).toBeNull();
   });
 
-  it("drops malformed or non-entry JSON", () => {
+  it("drops malformed or non-entry JSON", async () => {
     const storage = memoryStorage();
     vi.stubGlobal("localStorage", storage);
-    storage.setItem("https://x/bad.json", "{not-json");
-    expect(getCachedData("https://x/bad.json")).toBeNull();
+    const physicalKey = `${CACHE_KEY_PREFIX}https://x/bad.json`;
+    storage.setItem(physicalKey, "{not-json");
+    const cache = createLocalGovCache();
+    expect(await cache.get("https://x/bad.json")).toBeNull();
 
-    storage.setItem("https://x/obj.json", JSON.stringify({ foo: 1 }));
-    expect(getCachedData("https://x/obj.json")).toBeNull();
-    expect(storage.getItem("https://x/obj.json")).toBeNull();
+    storage.setItem(
+      `${CACHE_KEY_PREFIX}https://x/obj.json`,
+      JSON.stringify({ foo: 1 }),
+    );
+    expect(await cache.get("https://x/obj.json")).toBeNull();
   });
 
-  it("ignores set failures and rejects invalid ttl", () => {
+  it("ignores set failures", async () => {
     const storage = memoryStorage();
     storage.setItem = () => {
       throw new Error("quota");
     };
     vi.stubGlobal("localStorage", storage);
-    expect(() =>
-      setCachedData("https://x/index.json", { ok: true }),
-    ).not.toThrow();
-
-    expect(() =>
-      setCachedData("https://x/index.json", { ok: true }, { ttlSeconds: -1 }),
-    ).toThrow(/cacheTtlSeconds/);
+    const cache = createLocalGovCache();
+    await expect(
+      cache.set("https://x/index.json", { ok: true }),
+    ).resolves.toBeUndefined();
   });
 
-  it("returns null when localStorage getter throws", () => {
+  it("returns null when localStorage getter throws", async () => {
     Object.defineProperty(globalThis, "localStorage", {
       configurable: true,
       get() {
         throw new Error("blocked");
       },
     });
-    expect(getCachedData("https://x/index.json")).toBeNull();
+    const cache = createLocalGovCache();
+    expect(await cache.get("https://x/index.json")).toBeNull();
+  });
+
+  it("purge({ all: true }) only removes prefixed keys", async () => {
+    const storage = memoryStorage();
+    vi.stubGlobal("localStorage", storage);
+    storage.setItem("other-app:key", "keep");
+    const cache = createLocalGovCache();
+    await cache.set("https://x/a.json", { a: 1 });
+    await cache.set("https://x/b.json", { b: 2 });
+
+    await cache.purge({ all: true });
+    expect(await cache.get("https://x/a.json")).toBeNull();
+    expect(await cache.get("https://x/b.json")).toBeNull();
+    expect(storage.getItem("other-app:key")).toBe("keep");
+  });
+
+  it("purge({ keys }) removes only listed logical keys", async () => {
+    const storage = memoryStorage();
+    vi.stubGlobal("localStorage", storage);
+    const cache = createLocalGovCache();
+    await cache.set("https://x/a.json", { a: 1 });
+    await cache.set("https://x/b.json", { b: 2 });
+
+    await cache.purge({ keys: ["https://x/a.json"] });
+    expect(await cache.get("https://x/a.json")).toBeNull();
+    expect(await cache.get("https://x/b.json")).toEqual({ b: 2 });
   });
 });

--- a/packages/jp-local-gov-id/src/cache.ts
+++ b/packages/jp-local-gov-id/src/cache.ts
@@ -1,101 +1,77 @@
-import { msg } from "./messages";
+import {
+  CACHE_TTL_MS as CACHIAN_CACHE_TTL_MS,
+  CachianEnvironmentError,
+  createCache,
+  DEFAULT_CACHE_TTL_SECONDS as CACHIAN_DEFAULT_CACHE_TTL_SECONDS,
+} from "@b4moss/cachian";
+import type { CachePurgeOptions } from "@b4moss/cachian";
+import { localStorageDriver } from "@b4moss/cachian/drivers/localStorage";
+import { get } from "@b4moss/cachian/methods/get";
+import { purge } from "@b4moss/cachian/methods/purge";
+import { set } from "@b4moss/cachian/methods/set";
+
 /** Default cache TTL for URL-fetched data: 1 year (in seconds). */
-export const DEFAULT_CACHE_TTL_SECONDS = 365 * 24 * 60 * 60;
+export const DEFAULT_CACHE_TTL_SECONDS = CACHIAN_DEFAULT_CACHE_TTL_SECONDS;
 
 /** @deprecated Prefer DEFAULT_CACHE_TTL_SECONDS. Kept for existing imports. */
-export const CACHE_TTL_MS = DEFAULT_CACHE_TTL_SECONDS * 1000;
+export const CACHE_TTL_MS = CACHIAN_CACHE_TTL_MS;
 
-export type CacheWriteOptions = {
+/** Physical localStorage key prefix (keeps purge({ all: true }) scoped). */
+export const CACHE_KEY_PREFIX = "jp-local-gov-id:";
+
+export type { CachePurgeOptions };
+
+export type LocalGovCache = {
+  get(key: string): Promise<unknown | null>;
+  set(
+    key: string,
+    data: unknown,
+    options?: { ttlSeconds?: number },
+  ): Promise<void>;
+  purge(options: CachePurgeOptions): Promise<void>;
+};
+
+export type CreateLocalGovCacheInstanceOptions = {
   /** Default: true */
   enabled?: boolean;
-  /** TTL in seconds. Default: DEFAULT_CACHE_TTL_SECONDS (1 year). */
+  /** Default: DEFAULT_CACHE_TTL_SECONDS */
   ttlSeconds?: number;
 };
 
-type CacheEntry = {
-  expiresAt: number;
-  data: unknown;
+const noopCache: LocalGovCache = {
+  async get() {
+    return null;
+  },
+  async set() {},
+  async purge() {},
 };
 
-function getLocalStorage(): Storage | null {
-  try {
-    if (typeof globalThis.localStorage === "undefined") return null;
-    return globalThis.localStorage;
-  } catch {
-    return null;
-  }
-}
-
-function isCacheEntry(value: unknown): value is CacheEntry {
-  if (value === null || typeof value !== "object") return false;
-  const o = value as Record<string, unknown>;
-  return typeof o.expiresAt === "number" && "data" in o;
-}
-
-function resolveTtlMs(ttlSeconds?: number): number {
-  const seconds =
-    ttlSeconds === undefined ? DEFAULT_CACHE_TTL_SECONDS : ttlSeconds;
-  if (!Number.isFinite(seconds) || seconds < 0) {
-    throw new TypeError(msg("cache.ttlSeconds"));
-  }
-  return seconds * 1000;
-}
-
-/** Read cached JSON for a versioned URL. Returns null on miss / expiry / unavailable. */
-export function getCachedData(
-  url: string,
-  options?: { enabled?: boolean },
-): unknown | null {
-  if (options?.enabled === false) return null;
-
-  const storage = getLocalStorage();
-  if (!storage) return null;
+/**
+ * Create a per-client cachian instance (localStorage + get/set/purge only).
+ * When localStorage is unavailable, returns a silent no-op cache.
+ */
+export function createLocalGovCache(
+  options: CreateLocalGovCacheInstanceOptions = {},
+): LocalGovCache {
+  const enabled = options.enabled !== false;
+  const ttlSeconds =
+    options.ttlSeconds === undefined
+      ? DEFAULT_CACHE_TTL_SECONDS
+      : options.ttlSeconds;
 
   try {
-    const raw = storage.getItem(url);
-    if (raw == null) return null;
-
-    const parsed: unknown = JSON.parse(raw);
-    if (!isCacheEntry(parsed)) {
-      storage.removeItem(url);
-      return null;
+    return createCache({
+      driver: localStorageDriver(),
+      methods: [get, set, purge],
+      enabled,
+      ttlSeconds,
+      keyPrefix: CACHE_KEY_PREFIX,
+    });
+  } catch (error) {
+    if (error instanceof CachianEnvironmentError) {
+      return noopCache;
     }
-
-    if (Date.now() >= parsed.expiresAt) {
-      storage.removeItem(url);
-      return null;
-    }
-
-    return parsed.data;
-  } catch {
-    try {
-      storage.removeItem(url);
-    } catch {
-      // ignore
-    }
-    return null;
-  }
-}
-
-/** Store fetch result under the versioned URL key. No-op without localStorage. */
-export function setCachedData(
-  url: string,
-  data: unknown,
-  options?: CacheWriteOptions,
-): void {
-  if (options?.enabled === false) return;
-
-  const storage = getLocalStorage();
-  if (!storage) return;
-
-  const entry: CacheEntry = {
-    expiresAt: Date.now() + resolveTtlMs(options?.ttlSeconds),
-    data,
-  };
-
-  try {
-    storage.setItem(url, JSON.stringify(entry));
-  } catch {
-    // QuotaExceeded or private mode — skip cache
+    // Defensive: treat any driver/bootstrap failure like "storage unavailable".
+    return noopCache;
   }
 }

--- a/packages/jp-local-gov-id/src/create.ts
+++ b/packages/jp-local-gov-id/src/create.ts
@@ -1,7 +1,7 @@
 import {
   DEFAULT_CACHE_TTL_SECONDS,
-  getCachedData,
-  setCachedData,
+  createLocalGovCache,
+  type LocalGovCache,
 } from "./cache";
 import { buildLocalGovClient } from "./api";
 import {
@@ -193,10 +193,10 @@ async function fetchAndCache<T>(
   url: string,
   load: () => Promise<unknown>,
   validate: (data: unknown) => T,
-  cache: ResolvedCacheConfig,
+  cache: LocalGovCache,
   options?: { persist?: boolean },
 ): Promise<T> {
-  const cached = getCachedData(url, { enabled: cache.enabled });
+  const cached = await cache.get(url);
   if (cached !== null) {
     return validate(cached);
   }
@@ -204,18 +204,19 @@ async function fetchAndCache<T>(
   const parsed = await load();
   const validated = validate(parsed);
   if (options?.persist !== false) {
-    setCachedData(url, validated, {
-      enabled: cache.enabled,
-      ttlSeconds: cache.ttlSeconds,
-    });
+    await cache.set(url, validated);
   }
   return validated;
 }
 
 async function createFromUrl(
   indexUrl: string,
-  cache: ResolvedCacheConfig,
+  cacheConfig: ResolvedCacheConfig,
 ): Promise<LocalGovClient> {
+  const cache = createLocalGovCache({
+    enabled: cacheConfig.enabled,
+    ttlSeconds: cacheConfig.ttlSeconds,
+  });
   // Normalize path-only bases (e.g. "/data/index.json") so sibling resolution works.
   const absoluteIndexUrl = toAbsoluteUrl(indexUrl);
 
@@ -271,7 +272,7 @@ async function createFromUrl(
     { prefecturesAsOf: prefecturesFile.asOf },
   );
 
-  return buildLocalGovClient(store);
+  return buildLocalGovClient(store, { cache });
 }
 
 async function createFromData(data: unknown): Promise<LocalGovClient> {
@@ -326,9 +327,10 @@ async function createFromData(data: unknown): Promise<LocalGovClient> {
  * Pass either `{ data }` (dataset) or `{ url }` (versioned index.json URL).
  *
  * For `url` mode, localStorage caching is on by default (`cache: true`,
- * `cacheTtlSeconds` defaults to 1 year). Cached values are decoded objects
- * stored via `JSON.stringify` (minified). JLIX and nationwide municipality
- * loads skip localStorage.
+ * `cacheTtlSeconds` defaults to 1 year) via `@b4moss/cachian` (localStorage
+ * driver + get/set/purge). Keys are prefixed with `jp-local-gov-id:`.
+ * Call `client.purgeCache(...)` to clear. Cached values are decoded objects
+ * (minified JSON). JLIX and nationwide municipality loads skip localStorage.
  */
 export async function createLocalGovClient(
   options: CreateLocalGovOptions,
@@ -349,8 +351,8 @@ export async function createLocalGovClient(
   }
 
   if (urlProvided) {
-    const cache = resolveCacheConfig(options);
-    return createFromUrl(options.url, cache);
+    const cacheConfig = resolveCacheConfig(options);
+    return createFromUrl(options.url, cacheConfig);
   }
 
   resolveCacheConfig(options);

--- a/packages/jp-local-gov-id/src/index.ts
+++ b/packages/jp-local-gov-id/src/index.ts
@@ -27,9 +27,11 @@ export {
 } from "./types";
 export { createLocalGovClient } from "./create";
 export {
+  CACHE_KEY_PREFIX,
   CACHE_TTL_MS,
   DEFAULT_CACHE_TTL_SECONDS,
 } from "./cache";
+export type { CachePurgeOptions } from "./cache";
 export {
   LOCAL_GOV_SCHEMA_VERSION,
   LocalGovSchemaError,

--- a/packages/jp-local-gov-id/src/types.ts
+++ b/packages/jp-local-gov-id/src/types.ts
@@ -1,3 +1,5 @@
+import type { CachePurgeOptions } from "./cache";
+
 export type MunicipalityCounts = {
   both: number;
   city: number;
@@ -176,6 +178,12 @@ export type LocalGovClient = {
     name: string,
     options?: SearchOptions,
   ): Promise<string | null>;
+  /**
+   * Purge URL-mode localStorage cache entries for this client.
+   * No-op in `data` mode or when `cache: false` / storage is unavailable.
+   * Options match `@b4moss/cachian` `CachePurgeOptions` (`all` / `keys` / time filters).
+   */
+  purgeCache(options: CachePurgeOptions): Promise<void>;
 };
 
 /** @deprecated Use LocalGovIndexFile / split file types. Kept for export compatibility. */

--- a/site/content/en/api.md
+++ b/site/content/en/api.md
@@ -14,7 +14,7 @@ Overview of the client returned by `createLocalGovClient`.
 |--------|-------------|
 | `data` | npm dataset (includes `searchNgramShards`) |
 | `url` | Versioned `index.json` URL (resolves sibling `.bin.br` paths) |
-| `cache` | localStorage cache for `url` mode (default `true`) |
+| `cache` | localStorage cache for `url` mode via `@b4moss/cachian` (default `true`). Keys use prefix `jp-local-gov-id:` |
 | `cacheTtlSeconds` | Cache TTL in seconds (default `31536000`) |
 
 Exactly one of `data` or `url` is required.
@@ -52,6 +52,7 @@ Exactly one of `data` or `url` is required.
 | `getByCode(code)` | `Promise<LocalGov \| null>` | 2- or 6-digit (6-digit prefers prefecture entity) |
 | `searchByText(text, options?)` | `Promise<LocalGov[]>` | Partial match |
 | `getLocalGovCodeByName(name, options?)` | `Promise<string \| null>` | Exact name → **6-digit** local-gov code |
+| `purgeCache(options)` | `Promise<void>` | Clear URL-mode localStorage cache (`{ all: true }` / `{ keys }` / etc. — cachian `CachePurgeOptions`) |
 
 ### `designatedCity`
 

--- a/site/content/ja/api.md
+++ b/site/content/ja/api.md
@@ -14,7 +14,7 @@ schemaRole: TechArticle
 |------------|------|
 | `data` | npm データセット（または同等オブジェクト。`searchNgramShards` 含む） |
 | `url` | `index.json` の版付き URL（配下の `.bin.br` を相対解決） |
-| `cache` | `url` モードの localStorage キャッシュ。既定 `true` |
+| `cache` | `url` モードの localStorage キャッシュ（`@b4moss/cachian`）。既定 `true`。キーは `jp-local-gov-id:` プレフィックス |
 | `cacheTtlSeconds` | キャッシュ TTL（秒）。既定 `31536000`（1 年） |
 
 どちらか一方が必須（`data` または `url`）。
@@ -52,6 +52,7 @@ schemaRole: TechArticle
 | `getByCode(code)` | `Promise<LocalGov \| null>` | 2 桁 / 6 桁を自動判定（6 桁は都道府県エンティティ優先） |
 | `searchByText(text, options?)` | `Promise<LocalGov[]>` | 部分一致検索 |
 | `getLocalGovCodeByName(name, options?)` | `Promise<string \| null>` | 正式名称から**地方公共団体コード（6 桁）** |
+| `purgeCache(options)` | `Promise<void>` | URL モードの localStorage キャッシュを削除（`{ all: true }` / `{ keys }` 等。cachian の `CachePurgeOptions`） |
 
 ### `designatedCity` オプション
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Issue #94: URL モードの自前 localStorage キャッシュを `@b4moss/cachian@0.4.0` に置き換え
- 取り込みは `localStorageDriver` + `get` / `set` / `purge` のみ
- 物理キーに `jp-local-gov-id:` prefix
- `LocalGovClient.purgeCache(options)` を追加（`CachePurgeOptions` を re-export）
- 自前 TTL 切れ処理は削除（cachian 側に委譲）

## Spec
- [`docs/test-spec-94-cachian-purge.md`](../blob/cursor/cachian-cache-purge-6db9/docs/test-spec-94-cachian-purge.md)

## Test plan
- [x] `npm test -w @b4moss/jp-local-gov-id`（202 tests passed）
- [x] `npm run build -w @b4moss/jp-local-gov-id`

## Breaking changes
- 旧キー（prefix なし URL）は読めない → 再フェッチ
- 自前 TTL 切れ保証をやめる
- エントリに `createdAt` が付く（cachian 形式）

Base: `dev-v1.1.0`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0755f-a41e-7c95-9994-54a7f27c6db9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0755f-a41e-7c95-9994-54a7f27c6db9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

