### PR TITLE
docs: #93 follow-up テスト仕様（初期チャンク ≤25KB）

### DIFF
--- a/docs/client-bundle-93.md
+++ b/docs/client-bundle-93.md
@@ -19,14 +19,15 @@ npm run measure:client-bundle -w @b4moss/jp-local-gov-id
 | minify | `true` |
 | external | `brotli-wasm`, `node:zlib` |
 
-サイズ超過だけではスクリプトは失敗しない（レポート用途）。25KB は目安であり必達ゲートではない。
+サイズ超過だけではスクリプトは失敗しない（レポート用途）。#93 本体では 25KB は目安だったが、[follow-up テスト仕様 §12](./test-spec-93-client-bundle.md) では初期チャンク ≤25600 を完了条件とする（CI fail ゲート化はしない）。
 
 ## 結果
 
 | 時点 | ブランチ / メモ | minify 生 | gzip |
 | --- | --- | ---: | ---: |
 | 分割前ベースライン（#85 後） | 単一 `MESSAGES` | 31620 | 8920 |
-| 分割後 | runtime / encode カタログ分割 + encode ファイル分離 + assert 共通化 | 30767 | 8846 |
+| 分割後（#128） | runtime / encode カタログ分割 + encode ファイル分離 + assert 共通化 | 30767 | 8846 |
+| follow-up 起点 | `dev-v1.2.0` + `dev-v1.1.0`（`@b4moss/cachian` 取り込み後） | 35428 | 10325 |
 
 差分: minify 生 **−853 B**（約 −2.7%）。encode 専用キーは create グラフおよび `decode.js` から除外済み。
 

--- a/docs/plan-93-followup-25kb.md
+++ b/docs/plan-93-followup-25kb.md
@@ -158,7 +158,7 @@
 - 追加:
   - 「search を呼ばない create」で search 実装モジュールが初期チャンクに含まれないこと（metafile アサーション、または測定スクリプトの回帰チェック）
   - lazy 後も `searchByText` のヒット順・件数互換
-- `docs/test-spec-93-client-bundle.md` に Phase ゲートと「初期チャンク vs search チャンク」の定義を追記
+- [x] `docs/test-spec-93-client-bundle.md` に Phase ゲートと「初期チャンク vs search/cache チャンク」の定義を追記（§12〜）
 
 ## 完了条件
 

--- a/docs/test-spec-93-client-bundle.md
+++ b/docs/test-spec-93-client-bundle.md
@@ -1,26 +1,40 @@
 # テスト仕様書: クライアント JS バンドル減量（#93）
 
 対象マイルストーン: `v1.2.0`  
-関連: Issue #93 / 作業ブランチ `cursor/issue-93-client-bundle-41e9` / 統合先 `dev-v1.2.0`  
+関連: Issue #93 / [≤25KB follow-up 計画](./plan-93-followup-25kb.md) / [計測ログ](./client-bundle-93.md)  
+作業ブランチ（follow-up）: `cursor/issue-93-client-25kb-12a3` / 統合先 `dev-v1.2.0`  
 前提: Issue #85（メッセージ JSONC 外だし）済み。[test-spec-85-messages-jsonc.md](./test-spec-85-messages-jsonc.md)  
 想定実装:
 
 - runtime 正本: `packages/jp-local-gov-id/src/messages.jsonc`
-- encode 正本: `packages/jp-local-gov-id/src/messages.encode.jsonc`（新規）
-- 生成物: `messages.generated.ts`（runtime）/ `messages.encode.generated.ts`（encode）
-- コンパイル: `packages/jp-local-gov-id/scripts/compile-messages.mjs`（両カタログ対応）
-- ランタイムヘルパ: `messages.ts`（runtime の `msg` / `fmt`）および encode 用ヘルパ（例: `messages.encode.ts`）
-- 計測: `packages/jp-local-gov-id/scripts/measure-client-bundle.mjs`（新規）
-- 計測手順ドキュメント: `docs/client-bundle-93.md`（新規）
+- encode 正本: `packages/jp-local-gov-id/src/messages.encode.jsonc`
+- search 正本（follow-up）: `packages/jp-local-gov-id/src/messages.search.jsonc`
+- 生成物: `messages.generated.ts` / `messages.encode.generated.ts` / `messages.search.generated.ts`（follow-up）
+- コンパイル: `packages/jp-local-gov-id/scripts/compile-messages.mjs`
+- ランタイムヘルパ: `messages.ts`（および encode / search 用ヘルパ）
+- 計測: `packages/jp-local-gov-id/scripts/measure-client-bundle.mjs`
+- 計測手順ドキュメント: `docs/client-bundle-93.md`
+
+本仕様は二段構えである。
+
+| 段 | 範囲 | 25KB の扱い |
+|------|------|-------------|
+| **A. #93 本体**（§1〜§11、PR #128） | runtime / encode カタログ分割・計測基盤 | 目安。未達でも本体は受け入れ可 |
+| **B. follow-up**（§12〜、本ブランチ） | 初期チャンク ≤25600（Search / cachian 遅延など） | **完了条件**（CI の fail ゲート化はしない） |
+
+---
+
+# A. #93 本体（PR #128）
 
 ## 1. 目的
 
-`createLocalGovClient` 利用時にツリーシェイク後へ残るクライアント JS（minify 生サイズ）を削減する。主施策は **メッセージカタログの runtime / encode 分割**である。
+`createLocalGovClient` 利用時にツリーシェイク後へ残るクライアント JS（minify 生サイズ）を削減する。本体の主施策は **メッセージカタログの runtime / encode 分割**である。
 
 - #85 の単一 `MESSAGES` により、encode / generate 専用キーまで create グラフへ載っていた問題を解消する
 - **`brotli-wasm` は残す**（Chromium 系は `DecompressionStream` の `"brotli"` 形式が未対応のため）
-- schema 検証は残す。パッケージ／入口の分割（`/search` 等）はこの Issue では行わない
-- **minify 生 25KB 以下は目安であり、必達ゲートにしない**（測って記録する）
+- schema 検証は残す
+- パッケージ公開入口の分割（`exports["./search"]` 等）は行わない（follow-up の動的 import によるチャンク分離とは別）
+- **本体時点では minify 生 25KB 以下は目安**（測って記録する）。必達は §12 の follow-up 完了条件とする
 
 ## 2. 用語
 
@@ -28,17 +42,17 @@
 |------|------|
 | create グラフ | `createLocalGovClient` をエントリとしたツリーシェイク後の依存モジュール集合 |
 | minify 生サイズ | esbuild `platform: "browser"` + `minify: true` の出力バイト数（gzip 前） |
-| runtime カタログ | create / decode / schema / search / cache / brotli が参照する文言正本 |
-| encode カタログ | `encode*` および `scripts/generate.ts` のみが参照する文言正本 |
+| runtime カタログ | create / decode / schema / cache / brotli、および（本体時点の）search が参照する文言正本 |
+| encode カタログ | `encode*` および generate のみが参照する文言正本 |
 | 計測スクリプト | create グラフの minify 生サイズを出力する Node スクリプト |
 
-対象の境界:
+対象の境界（本体）:
 
 | 含む | 含まない |
 |------|----------|
 | `@b4moss/jp-local-gov-id` の create グラフ減量 | Node 専用容量最適化を主目的にすること |
 | メッセージカタログ分割と compile 配線 | `brotli-wasm` の削除 |
-| 計測スクリプトと手順ドキュメント | `/search` や codec へのパッケージ分割 |
+| 計測スクリプトと手順ドキュメント | 公開 `exports` への `/search` パッケージ分割 |
 | binary assert 共通化など軽い整理 | schema 検証の削除・デコード任せ化 |
 | | サイト（`site/`）・多言語化 |
 
@@ -50,70 +64,70 @@
 
 - **期待**: runtime 正本 `messages.jsonc` と encode 正本 `messages.encode.jsonc` が存在する
 - **期待**: 同一キーが両カタログに重複して定義されない
-- **期待**: 両カタログとも #85 のキー命名・プレースホルダ契約（TC-M02 / TC-M03）を満たす
+- **期待**: 両カタログとも #85 のキー命名・プレースホルダ契約を満たす
+
+> follow-up（§12）で search 正本を追加したあとは「正本が三つ」になる。重複禁止は全正本間に拡張する（TC-F-S01）。
 
 ### TC-S02: encode 専用キーの帰属
 
-少なくとも次のキー（現行 `messages.jsonc` 上の識別子）は **encode カタログのみ**に置く。
+少なくとも次のキー（現行識別子）は **encode カタログのみ**に置く。
 
 | キー | 主な発生元 |
 |------|------------|
 | `binary.jldt.encodeSizeMismatch` | `encodeMunicipalities` |
 | `binary.jlpr.encodeSizeMismatch` | `encodePrefectures` |
 | `binary.jlix.encodeSizeMismatch` | `encodeSearchNgrams` |
-| `binary.asOfExceedsU1` | 各 `encode*` |
-| `binary.recordCountExceedsU2` | 各 `encode*` |
-| `binary.versionOutOfU1` | `encodeMunicipalities`（encode 経路のみなら） |
-| `data.unknownPrefectureCode` | `scripts/generate.ts` → `dataset.js` |
+| encode 専用の範囲・バージョン系 | 各 `encode*` |
+| generate 専用の data 系 | generate / dataset 埋め込み |
 
 - **期待**: 上記キーが runtime 生成モジュール（`messages.generated.ts`）に現れない
-- **判定基準**: decode 経路から一度も呼ばれないキーのみ encode へ移す。decode と共有する `binary.fieldOutOfU1` / `binary.fieldOutOfU4` / `binary.fieldMustBe0Or1` / `binary.unsupportedVersion` / `binary.*.shortVersionAsOfLen` 等の short\* / string table 系は runtime に残す
+- **判定基準**: decode 経路から一度も呼ばれないキーのみ encode へ移す。decode と共有する short\* / string table 系は runtime に残す
 
 ### TC-S03: runtime キーの帰属
 
-- **期待**: `schema.*` / `create.*` / `cache.*` / `brotli.*` / `search.*` および decode 経路の `binary.*` は runtime カタログにある
-- **期待**: `create.unknownPrefectureDecode` のように create / decode 経路で使うキーは runtime に残す（`data.unknownPrefectureCode` と混同しない）
+- **期待（本体）**: `schema.*` / `create.*` / `cache.*` / `brotli.*` / `search.*` および decode 経路の `binary.*` は runtime カタログにある
+- **期待**: create / decode 経路で使うキーは runtime に残す
 - **期待**: create グラフ上の `msg` / `fmt` 呼び出しが参照するキーは、すべて runtime カタログで解決できる
+
+> **follow-up 改訂（TC-F-S02）:** Phase B 以降、`search.*` および検索時専用の create キー（例: `create.missingSearchNgramShards`）は **search カタログ**へ移してよい。その場合、初期チャンク（core）の `msg` / `fmt` は core カタログのみで解決できればよい。
 
 ### TC-S04: import 境界
 
-- **期待**: decode / schema / create / search / cache / brotli は runtime ヘルパ（`messages.ts` の `msg` / `fmt`）のみを import する
-- **期待**: `encodePrefectures` / `encodeMunicipalities` / `encodeSearchNgrams` 内の throw は encode ヘルパを import する
-- **期待**: runtime モジュールが encode 生成モジュール / encode ヘルパを import しない
-- **推奨**: 自動テストまたは静的検査で「runtime → encode」逆依存がないことを検出する
+- **期待**: decode / schema / create / search / cache / brotli は、それぞれが属するカタログのヘルパのみを import する
+- **期待**: `encode*` 内の throw は encode ヘルパを import する
+- **期待**: runtime（core）モジュールが encode 生成モジュール / encode ヘルパを import しない
+- **推奨**: 自動テストまたは静的検査で「core → encode」逆依存がないことを検出する
 
-### TC-S05: compile が両カタログを生成する
+### TC-S05: compile がカタログを生成する
 
 - **操作**: `compile-messages.mjs` を実行
-- **期待**: `messages.generated.ts` と `messages.encode.generated.ts` が更新される
+- **期待**: 各正本に対応する `*.generated.ts` が更新される
 - **期待**: 各生成物のキー集合が、対応する正本と一致する
-- **期待**: 不正 JSONC / 非 string 値 / 不正キー名では非 0 終了し、壊れた生成物を黙って出荷しない（#85 TC-C04 相当を両正本に適用）
+- **期待**: 不正 JSONC / 非 string 値 / 不正キー名では非 0 終了し、壊れた生成物を黙って出荷しない
 
-### TC-S06: build / test が両 compile を先行する
+### TC-S06: build / test が compile を先行する
 
-- **期待**: `packages/jp-local-gov-id` の `build` / `test` が、本体の前に両カタログの compile を実行する
-- **期待**: リポジトリには両正本と両生成物をコミットする
+- **期待**: `packages/jp-local-gov-id` の `build` / `test` が、本体の前にカタログ compile を実行する
+- **期待**: リポジトリには正本と生成物をコミットする
 
 ## 4. data / generate 連携ケース（TC-G）
 
 ### TC-G01: dataset の未知都道府県コードは encode カタログ由来
 
-- **前提**: `data.unknownPrefectureCode` は encode カタログにある
-- **操作**: `scripts/generate.ts` が encode カタログから文言を解決して `dataset.js` に埋め込む
-- **期待**: 未知コードで `Error` となり、メッセージ意味は現行同等（部分一致 `/Unknown prefecture code/`）
+- **操作**: generate が encode カタログから文言を解決して埋め込む
+- **期待**: 未知コードで `Error` となり、メッセージ意味は現行同等
 - **期待**: generate が runtime カタログだけを読んで欠落エラーにならない
 
 ### TC-G02: decode.js は runtime のみを埋め込む
 
-- **操作**: 既存の decode 再生成（generate）を実行
-- **期待**: `packages/jp-local-gov-id-data/decode.js` に埋め込まれるメッセージは runtime キーのみ
-- **期待**: encode 専用キー（`*.encodeSizeMismatch` / `data.unknownPrefectureCode` 等）が `decode.js` に現れない
-- **期待**: decode 経路のエラー意味は現行と同等（既存 binary / data テスト）
+- **期待**: data パッケージの decode 埋め込みメッセージは runtime（core）キーのみ
+- **期待**: encode 専用キーが decode 成果物に現れない
+- **期待**: decode 経路のエラー意味は現行と同等
 
 ### TC-G03: data パッケージに追加の正本を置かない
 
-- **期待**: 文言正本は `jp-local-gov-id` 側の runtime / encode の二つだけ
-- **期待**: `jp-local-gov-id-data` 配下に別の messages カタログを新設しない（#85 TC-D03 の延長）
+- **期待**: 文言正本は `jp-local-gov-id` 側に置く
+- **期待**: `jp-local-gov-id-data` 配下に別の messages カタログを新設しない
 
 ## 5. バンドル計測ケース（TC-B）
 
@@ -121,55 +135,54 @@
 
 ### TC-B01: 計測エントリと条件
 
-- **操作**: 計測スクリプトを実行
-- **期待**: エントリは `createLocalGovClient`（`src/create.ts` 経由）。`src/index.ts` の全 export をエントリにしない
+- **操作**: `npm run measure:client-bundle -w @b4moss/jp-local-gov-id`
+- **期待**: エントリは `createLocalGovClient`（`src/create.ts` を named export 経由）。`src/index.ts` の全 export をエントリにしない
 - **期待**: esbuild 条件は少なくとも次を満たす:
   - `bundle: true`
   - `platform: "browser"`
   - `format: "esm"`
   - `minify: true`
   - `external: ["brotli-wasm", "node:zlib"]`（または同等）
-- **期待**: 標準出力（または成果ファイル）に minify 生バイト数が含まれる
+- **期待**: 標準出力に minify 生バイト数が含まれる
 - **推奨**: 参考値として gzip 後サイズも出してよい
 
 ### TC-B02: npm script から実行できる
 
-- **期待**: `packages/jp-local-gov-id` に `measure:client-bundle`（名称同等可）がある
+- **期待**: `packages/jp-local-gov-id` に `measure:client-bundle` がある
 - **期待**: 依存不足やエントリ解決失敗時は非 0 終了し、理由が分かる
 
 ### TC-B03: 分割後に encode 専用キーが create グラフへ載らない
 
 - **前提**: カタログ分割後
 - **操作**: 計測（または同等の esbuild metafile / 出力検査）
-- **期待**: 出力 JS に encode 専用メッセージ文字列（例: `Internal encode size mismatch (JLDT)` / `(JLPR)` / `(JLIX)`、`Unknown prefecture code`）が含まれない
-- **期待**: runtime で必要な代表文言（schema / create / decode の short\* 等）は、該当経路がバンドルに含まれる場合に解決できる
+- **期待**: 出力 JS に encode 専用メッセージ文字列が含まれない
+- **期待**: runtime で必要な代表文言は、該当経路がバンドルに含まれる場合に解決できる
 
 ### TC-B04: 計測結果をドキュメントに残す
 
-- **期待**: `docs/client-bundle-93.md`（または同等）に次を記録する:
+- **期待**: `docs/client-bundle-93.md` に次を記録する:
   - 測定コマンド
   - 測定条件（エントリ・platform・minify・external）
-  - 分割前（可能なら）と分割後の minify 生サイズ
+  - 時点ごとの minify 生サイズ
   - 測定日 / コミットまたはブランチ
-- **期待**: 25KB 未満かどうかは記載してよいが、未達でも本 Issue の失敗条件にはしない
+- **期待（本体）**: 25KB 未満かどうかは記載してよいが、未達でも #93 本体の失敗条件にはしない
 
 ### TC-B05: 計測スクリプトはサイズ未達で fail しない
 
 - **操作**: create グラフが 25KB を超える状態で計測スクリプトを実行
-- **期待**: サイズ超過のみを理由に非 0 終了しない（レポート用途）
+- **期待**: サイズ超過のみを理由に非 0 終了しない（レポート用途）。follow-up 完了判定は人間 / PR チェックリストで行う
 
 ## 6. Brotli / 互換ケース（TC-Z）
 
 ### TC-Z01: brotli-wasm フォールバックを残す
 
-- **期待**: ブラウザ経路で `DecompressionStream("brotli")`（および実装が試す `"br"`）が使えない場合、`brotli-wasm` へフォールバックする実装が残る
+- **期待**: ブラウザ経路で `DecompressionStream("brotli")`（および実装が試す同等形式）が使えない場合、`brotli-wasm` へフォールバックする実装が残る
 - **期待**: `brotli-wasm` が `package.json` 依存およびビルド external から意図せず消えない
-- **実装先**: `brotli.test.ts` の既存フォールバックケースを維持
 
 ### TC-Z02: 現代ブラウザ / Node 経路
 
 - **期待**: `DecompressionStream` 利用時に `.bin.br` が従来どおり展開できる
-- **期待**: Node では `node:zlib` 経路が従来どおり動く（Node 容量削減を目的化しない）
+- **期待**: Node では `node:zlib` 経路が従来どおり動く
 
 ### TC-Z03: ドキュメントの前提
 
@@ -178,17 +191,15 @@
 
 ## 7. 回帰・公開 API ケース（TC-R）
 
-既存テストを主たる受け入れとする。
-
 ### TC-R01: 公開 API・schema 検証
 
 - **期待**: 既存の公開 API テストがパスする
-- **期待**: schema 検証を削除・迂回しない（デコード成功だけに任せない）
-- **期待**: 例外クラス（`LocalGovSchemaError` / `LocalGovBinaryError` 等）を意図せず変えない
+- **期待**: schema 検証を削除・迂回しない
+- **期待**: 例外クラスを意図せず変えない
 
 ### TC-R02: encode API のメッセージ
 
-- **期待**: `encodePrefectures` / `encodeMunicipalities` / `encodeSearchNgrams` の既存エラーケースがパスする
+- **期待**: `encode*` の既存エラーケースがパスする
 - **期待**: メッセージは encode カタログ由来でも、意味・部分一致期待を維持する
 
 ### TC-R03: create / fetch / cache / search / binary decode
@@ -198,46 +209,202 @@
 
 ### TC-R04: 公開 exports にメッセージを載せない
 
-- **期待**: runtime / encode いずれのカタログも `msg` / `fmt` も、パッケージ公開 `exports` / `src/index.ts` から出さない（#85 TC-C05 の延長）
+- **期待**: カタログも `msg` / `fmt` も、パッケージ公開 `exports` / `src/index.ts` から出さない
 
 ## 8. 付随整理ケース（TC-L）— 実施する場合
 
-分割後の任意作業。実施するなら次を満たす。
-
 ### TC-L01: binary assert 共通化
 
-- **期待**: `prefectures.ts` / `municipalities.ts` / `searchNgrams.ts` に三重定義されていた assert 系ヘルパを共有モジュールへ寄せても、binary テストがパスする
-- **期待**: エラー意味（ラベル・範囲・trailing bytes）を壊さない
+- **期待**: 三重定義されていた assert 系ヘルパを共有モジュールへ寄せても、binary テストがパスする
+- **期待**: エラー意味を壊さない
 
 ### TC-L02: minify 向けの軽い寄せ
 
-- **期待**: encode 専用のモジュールローカル（例: magic 定数・encoder）を decode グラフから外す変更を入れた場合、decode / create テストがパスする
+- **期待**: encode 専用モジュールを decode / create グラフから外す変更を入れた場合、decode / create テストがパスする
 - **期待**: 公開 encode API の行為は維持する
 
-## 9. 非対象（明示）
+## 9. 非対象（#93 本体および follow-up 共通）
 
-次は本仕様書のテストケースに含めない。
+次はテストケースに含めない / 採用しない。
 
 - `brotli-wasm` の削除、および DS のみ前提への切り替え
-- `/search` や codec 入口への分割による減量（必要ならフォローアップ Issue）
+- Brotli 経路の間引きを **バンドルサイズ目的**で行うこと
+- 公開 `package.json` exports への `/search` や codec 入口追加による減量
 - Node 向けバンドルサイズの最適化を主目的にした変更
 - schema 検証の削除
-- 25KB 必達を CI ゲート化すること
+- **25KB 必達を CI で fail させるゲート化**（完了条件としての判定は PR / チェックリストで行う）
 - サイト（`site/`）のバンドルサイズ
 - メッセージの多言語化・エラーコード（数値 / symbol）化
 
-## 10. 受け入れ条件
+> 公開入口の分割は非対象だが、**アプリ側 Vite/esbuild がツリーシェイクしやすいよう、実装内部の動的 `import()` によるチャンク分離は follow-up の対象**である。
+
+## 10. 受け入れ条件（#93 本体）
 
 1. TC-S01〜S06 を満たし、runtime / encode カタログが分離されている
-2. TC-G01〜G03 を満たし、`dataset.js` / `decode.js` が正しいカタログに追従する
+2. TC-G01〜G03 を満たす
 3. TC-B01〜B05 を満たし、計測手段と比較結果が docs に残っている
 4. TC-Z01〜Z03 を満たし、`brotli-wasm` フォールバックが維持されている
 5. TC-R01〜R04 の回帰・公開 API 制約を満たす
-6. minify 生 25KB 以下は望ましいが、**未達でも 1〜5 を満たせば本 Issue は受け入れ可**とする
+6. minify 生 25KB 以下は望ましいが、**未達でも 1〜5 を満たせば #93 本体は受け入れ可**とする（必達は §12）
 7. TC-L を実施した場合は、対応ケースもパスする
 
 ## 11. #85 仕様との関係
 
-- 本 Issue は #85 の単一カタログ前提を、**双カタログ**へ拡張する
-- #85 の TC-M / TC-C / TC-H / TC-R / TC-D の意図（意味維持・公開 API 非公開・直書き禁止）は維持する
-- 実装時は [test-spec-85-messages-jsonc.md](./test-spec-85-messages-jsonc.md) に「正本が runtime / encode の二つ」である旨を追記してよい（本仕様が詳細の正とする）
+- 本 Issue は #85 の単一カタログ前提を、**双カタログ**（follow-up では search を含め最大三カタログ）へ拡張する
+- #85 の意図（意味維持・公開 API 非公開・直書き禁止）は維持する
+
+---
+
+# B. follow-up: createLocalGovClient 初期チャンク ≤25KB
+
+関連計画: [plan-93-followup-25kb.md](./plan-93-followup-25kb.md)  
+作業ブランチ: `cursor/issue-93-client-25kb-12a3`
+
+## 12. follow-up の目的と指標
+
+### 12.1 目的
+
+消費側（Vite / esbuild 等）が `createLocalGovClient` だけを取り込んだときの **初期チャンク** minify 生を **≤ 25600** にする。CDN 向けフル IIFE（`iife.min.js`）の削減は本 follow-up の主指標ではない。
+
+### 12.2 用語（follow-up 追加）
+
+| 用語 | 意味 |
+|------|------|
+| 初期チャンク | 計測エントリ（named export `createLocalGovClient`）を esbuild したとき、動的 `import()` 先を除いた主出力の minify 生バイト数 |
+| search チャンク | `searchByText` / `getLocalGovCodeByName` 等の初回実行で載る動的 import 先（参考値） |
+| cache チャンク | URL + cache 経路で載る `@b4moss/cachian` / `cache` 実装の動的 import 先（参考値） |
+| core カタログ | 初期チャンクが参照する runtime 文言（`messages.jsonc`） |
+| search カタログ | search チャンクのみが参照する文言（`messages.search.jsonc`） |
+
+### 12.3 測定条件（固定）
+
+TC-B01 に加え、follow-up では次を満たす。
+
+| 項目 | 値 |
+|------|------|
+| 主指標 | **初期チャンク** minify 生 |
+| 参考指標 | search チャンク / cache チャンクの minify 生、および初期チャンク gzip |
+| metafile | Phase 0 以降、上位モジュール（bytesInOutput）を出せること |
+| external | `brotli-wasm`, `node:zlib`（変更しない） |
+
+### 12.4 ベースラインとゲート
+
+| 時点 | 初期チャンク minify 生 | 備考 |
+|------|----------------------:|------|
+| #128 直後 | 30767 | cachian 前 |
+| follow-up 起点（dev-v1.1.0 取り込み後） | **35428** | `@b4moss/cachian` 込み |
+| 中間ゲート（Phase A+B 後） | **≤ 27000** | PR1 |
+| 最終ゲート（Phase C–E 後） | **≤ 25600** | PR2 / follow-up 完了 |
+
+未達の場合は残ギャップと次候補を PR に残し、推測だけで閉じない。
+
+## 13. チャンク分離ケース（TC-F）
+
+### TC-F01: 初期チャンクに search 実装が載らない
+
+- **前提**: Phase A1 以降
+- **操作**: search を呼ばない `createLocalGovClient` の初期チャンクを metafile / 計測で検査
+- **期待**: 少なくとも次が初期チャンクに実質含まれない（stub / 動的 import 文字列のみは可）
+  - `searchIndexLoader`
+  - `searchIndex`（クエリ実装）
+  - `binary` 配下の JLIX / search-ngrams **decode 実装が search 専用として分離された部分**
+- **期待**: 都道府県・市区町村の通常 lookup / list は静的経路のまま動作する
+
+### TC-F02: 初期チャンクに cachian が載らない
+
+- **前提**: Phase A2 以降
+- **操作**: 初期チャンクを metafile / 出力検査
+- **期待**: `@b4moss/cachian` およびその drivers/methods が初期チャンクに含まれない
+- **期待**: URL + cache 有効経路では、初回の cache 読み書きまたは `purgeCache` 実行時に cache チャンクが載り、既存 cache / purge テストがパスする
+- **期待**: dataset モード（URL なし）の create が cache 実装なしで完了できる
+
+### TC-F03: 公開 API 契約は維持
+
+- **期待**: `LocalGovClient.searchByText(...): Promise<...>` および `getLocalGovCodeByName(...): Promise<...>` のシグネチャを壊さない
+- **期待**: `purgeCache` の公開シグネチャを壊さない
+- **期待**: dataset で search ngram shards 欠落時、**create 時点では投げず**、検索実行時に既存どおりエラーになる（キー例: `create.missingSearchNgramShards`）
+- **期待**: 都道府県スコープ検索など、JLIX を使わない経路の意味を維持する
+
+### TC-F04: lazy 後の search 互換
+
+- **操作**: 既存 search 回帰（ヒット順・件数・asOf 不一致など）
+- **期待**: 動的 import 導入後もパスする
+- **期待**: 初回 `searchByText` で search チャンク読み込み後、2 回目以降も結果互換
+
+### TC-F05: 計測が初期チャンクと遅延チャンクを区別する
+
+- **期待**: `measure-client-bundle.mjs` が初期チャンクサイズを主出力する
+- **期待**: 動的 import がある場合、search / cache チャンクサイズを参考値として併記できる（Phase 0）
+- **期待**: `--meta`（または同等）で bytesInOutput 上位を提示できる
+
+## 14. search カタログ分離ケース（TC-F-S）
+
+### TC-F-S01: search 正本の追加
+
+- **前提**: Phase B 以降
+- **期待**: `messages.search.jsonc` と `messages.search.generated.ts` が存在する
+- **期待**: 同一キーが core / encode / search のどの正本間でも重複しない
+
+### TC-F-S02: search キーの帰属
+
+- **期待**: 少なくとも `search.*` は search カタログにある
+- **期待**: 検索実行時専用の create キー（例: `create.missingSearchNgramShards`）は search カタログへ移してよい
+- **期待**: 初期チャンクから参照される `msg` / `fmt` キーは core カタログで解決できる
+- **期待**: search チャンク側のみが search カタログを import する
+
+### TC-F-S03: compile / テスト分割
+
+- **期待**: `compile-messages.mjs` が search 正本を生成する
+- **期待**: メッセージ網羅テストが core / search（および encode）に更新されている
+
+## 15. 密度圧縮ケース（TC-F-D）— Phase C–E
+
+### TC-F-D01: schema densification
+
+- **期待**: 検証セマンティクス（不正ペイロードで throw）を維持したまま、表駆動化等で初期チャンクが減る
+- **期待**: `schema` 関連テストがパスする
+- **期待**: 公開エラーの意味が壊れない（文言短縮は可、キー改名は CHANGELOG 要）
+
+### TC-F-D02: message 短縮
+
+- **期待**: core カタログの文言短縮後も、エラーの「何がダメか」が分かる
+- **期待**: 部分一致を使う既存テストを更新したうえでパスする
+
+### TC-F-D03: normalize 圧縮
+
+- **期待**: 正規化の入出力互換を維持する
+- **期待**: search 専用正規化を search チャンクへ移した場合、初期チャンク metafile から消える（または stub のみ）
+
+## 16. Phase ゲート（チェックリスト）
+
+| Phase | 内容 | ゲート |
+|------|------|--------|
+| 0 | metafile / チャンク併記 | TC-F05。`client-bundle-93.md` に起点行（35428）がある |
+| A1 | Search lazy-load | TC-F01 / F03 / F04。起点比で初期チャンク **≥ 3.5KB 減**を目安 |
+| A2 | cachian 遅延 | TC-F02。初期チャンクから cachian 消失 |
+| B | search メッセージ分離 | TC-F-S01〜S03。A+B 後 **≤ 27000** |
+| C–E | schema / 文言 / normalize | TC-F-D01〜D03。最終 **≤ 25600** |
+
+PR 分割の目安: PR1 = Phase 0+A1+A2+B、PR2 = C–E。
+
+## 17. 受け入れ条件（follow-up）
+
+1. §12 の測定条件で、初期チャンク minify 生 **≤ 25600**
+2. TC-F01〜F05 および TC-F-S（Phase B 実施後）を満たす
+3. Phase C–E を実施した場合は TC-F-D を満たす
+4. `brotli-wasm` は依存・ブラウザフォールバックとして残存（TC-Z）
+5. 公開 API 互換（TC-F03 / TC-R）
+6. `docs/client-bundle-93.md` に Phase ごとの実測が並ぶ
+7. 計測スクリプトはサイズ未達だけで非 0 終了しない（TC-B05）。完了判定は本節の条件で行う
+8. 未達時は残ギャップと次候補を PR に明記する
+
+## 18. 実装時の参照ファイル（目安）
+
+| 領域 | ファイル |
+|------|----------|
+| create / 遅延配線 | `src/create.ts`, `src/store.ts` |
+| search 分離 | `src/api.ts`, `src/api.search.ts`（新規）, `src/searchIndexLoader.ts` |
+| cache 遅延 | `src/cache.ts`, create の URL 経路 |
+| カタログ | `messages.jsonc`, `messages.search.jsonc`（新規）, `scripts/compile-messages.mjs` |
+| 計測 | `scripts/measure-client-bundle.mjs`, `docs/client-bundle-93.md` |
+| 密度 | `src/schema.ts`, `src/normalize.ts`, messages 正本 |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`createLocalGovClient` 初期チャンク ≤25600 向け follow-up のテスト仕様を更新しました。

## Changes

- [`docs/test-spec-93-client-bundle.md`](docs/test-spec-93-client-bundle.md)
  - #93 本体（runtime/encode 分割）と follow-up を二段構えで整理
  - §12〜: 初期チャンク vs search/cache チャンクの定義
  - TC-F / TC-F-S / TC-F-D と Phase ゲート（中間 ≤27000、最終 ≤25600）
  - Search / cachian 遅延・公開 API 互換の受け入れ条件
- [`docs/client-bundle-93.md`](docs/client-bundle-93.md): follow-up では ≤25600 を完了条件と明記、起点サイズ追記
- [`docs/plan-93-followup-25kb.md`](docs/plan-93-followup-25kb.md): 仕様追記チェックを完了に更新

## Notes

実装（Phase 0 以降）はこのブランチで続けます。ベースは `dev-v1.2.0`（cachian 取り込み PR #129 未マージのため、本ブランチは merge tip 起点）。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a07597-2784-7f5f-847c-3ae8f50d12a3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a07597-2784-7f5f-847c-3ae8f50d12a3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

