### PR TITLE
ci: docs/site 更新時の冗長 CI をスキップ

### DIFF
--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -1,5 +1,7 @@
 # Docs CI — PRs targeting doc-site only.
-# Builds the documentation site; does not run app tests or app package build as a gate.
+# Builds the documentation site when site logic / config changes.
+# Pure content updates (markdown, site/content, static public assets) skip the
+# heavy build; Deploy Docs still publishes content on merge to doc-site.
 # App CI (ci.yml) is intentionally out of scope for this branch.
 name: Docs CI
 
@@ -14,18 +16,77 @@ concurrency:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
+  gate:
+    name: Gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      skip_heavy: ${{ steps.decide.outputs.skip_heavy }}
+      reason: ${{ steps.decide.outputs.reason }}
+    steps:
+      - name: Decide content-only / full
+        id: decide
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            // Content-only: no Nuxt/JS/config changes → skip Docs Build.
+            // Site logic (app/, server/, nuxt.config, package.json, i18n, …) → build.
+            const isContentOnlyPath = (p) =>
+              p.startsWith('docs/') ||
+              p.startsWith('site/content/') ||
+              p.startsWith('site/public/') ||
+              p.endsWith('.md') ||
+              p === 'LICENSE' ||
+              p === 'site/site.meta.yaml.example' ||
+              (p.startsWith('.github/') && p.endsWith('.md'));
+
+            const pr = context.payload.pull_request;
+            if (!pr) {
+              core.setOutput('skip_heavy', 'false');
+              core.setOutput('reason', 'full');
+              return;
+            }
+
+            const base = context.repo;
+            const { data: comp } = await github.rest.repos.compareCommits({
+              owner: base.owner,
+              repo: base.repo,
+              base: pr.base.sha,
+              head: pr.head.sha,
+            });
+            const files = comp.files || [];
+            const isContentOnly =
+              files.length > 0 && files.every((f) => isContentOnlyPath(f.filename));
+            if (isContentOnly) {
+              core.setOutput('skip_heavy', 'true');
+              core.setOutput('reason', 'content-only');
+              core.info('Skip Docs Build: content-only change set');
+              return;
+            }
+
+            core.setOutput('skip_heavy', 'false');
+            core.setOutput('reason', 'full');
+
   build:
     name: Docs Build
+    needs: gate
     runs-on: ubuntu-latest
     timeout-minutes: 15
-
     steps:
+      - name: Skip heavy work
+        if: needs.gate.outputs.skip_heavy == 'true'
+        run: |
+          echo "Docs Build skipped (${{ needs.gate.outputs.reason }}); treating as success."
+
       - name: Checkout
+        if: needs.gate.outputs.skip_heavy != 'true'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
+        if: needs.gate.outputs.skip_heavy != 'true'
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
@@ -33,6 +94,7 @@ jobs:
 
       # Docs build needs site + library/data workspaces (not scripts).
       - name: Install dependencies (site workspaces)
+        if: needs.gate.outputs.skip_heavy != 'true'
         run: >
           npm ci
           -w jp-local-gov-id-site
@@ -41,6 +103,7 @@ jobs:
           --include-workspace-root
 
       - name: Build site
+        if: needs.gate.outputs.skip_heavy != 'true'
         env:
           NITRO_PRESET: static
         run: npm run build:site

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,20 +47,47 @@ jobs:
               return;
             }
 
+            // App Test/Build is irrelevant for docs / documentation-site trees.
+            // site/** is covered by Docs CI / Deploy Docs, not this workflow.
+            const isAppCiSkippable = (p) =>
+              p.startsWith('docs/') ||
+              p.startsWith('site/') ||
+              p.endsWith('.md') ||
+              p === 'LICENSE' ||
+              (p.startsWith('.github/') && p.endsWith('.md')) ||
+              p === '.github/workflows/ci-docs.yml' ||
+              p === '.github/workflows/deploy-docs.yml';
+
+            const base = context.repo;
             const pr = context.payload.pull_request;
-            if (!pr) {
+            let baseSha = null;
+            let headSha = null;
+
+            if (pr) {
+              baseSha = pr.base.sha;
+              headSha = pr.head.sha;
+            } else if (context.eventName === 'push') {
+              // Push to main/release: compare against the previous tip so
+              // docs-only merges skip Test/Build (Codecov not needed).
+              baseSha = context.payload.before;
+              headSha = context.sha;
+              if (!baseSha || /^0+$/.test(baseSha)) {
+                core.setOutput('skip_heavy', 'false');
+                core.setOutput('reason', 'full');
+                core.info('No usable before SHA; running full CI');
+                return;
+              }
+            } else {
               core.setOutput('skip_heavy', 'false');
-              core.setOutput('reason', 'no-pr');
+              core.setOutput('reason', 'no-compare');
               return;
             }
 
-            const sha = pr.head.sha;
-            const base = context.repo;
             const { data: runs } = await github.rest.actions.listWorkflowRuns({
               owner: base.owner,
               repo: base.repo,
               workflow_id: 'ci.yml',
-              head_sha: sha,
+              head_sha: headSha,
               status: 'completed',
               per_page: 30,
             });
@@ -70,34 +97,24 @@ jobs:
             if (priorSuccess) {
               core.setOutput('skip_heavy', 'true');
               core.setOutput('reason', 'sha-already-green');
-              core.info(`Skip heavy jobs: CI already succeeded for ${sha}`);
+              core.info(`Skip heavy jobs: CI already succeeded for ${headSha}`);
               return;
             }
 
-            // Docs-only path filter via compare API
+            // Docs / site-only path filter via compare API (PR and push)
             const { data: comp } = await github.rest.repos.compareCommits({
               owner: base.owner,
               repo: base.repo,
-              base: pr.base.sha,
-              head: sha,
+              base: baseSha,
+              head: headSha,
             });
             const files = comp.files || [];
-            const isDocsOnly =
-              files.length > 0 &&
-              files.every((f) => {
-                const p = f.filename;
-                return (
-                  p.startsWith('docs/') ||
-                  p.startsWith('site/content/') ||
-                  p.endsWith('.md') ||
-                  p === 'LICENSE' ||
-                  (p.startsWith('.github/') && p.endsWith('.md'))
-                );
-              });
-            if (isDocsOnly) {
+            const isDocsOrSiteOnly =
+              files.length > 0 && files.every((f) => isAppCiSkippable(f.filename));
+            if (isDocsOrSiteOnly) {
               core.setOutput('skip_heavy', 'true');
               core.setOutput('reason', 'docs-only');
-              core.info('Skip heavy jobs: docs-only change set');
+              core.info('Skip heavy jobs: docs/site-only change set');
               return;
             }
 

--- a/docs/ci-cd.ja.md
+++ b/docs/ci-cd.ja.md
@@ -36,20 +36,25 @@ npm run ci:local:fallback   # npm ci && npm test && npm run build
 |------|--------|
 | トリガ | base が `develop` または `dev-*` の `pull_request`、および **`main` / `release` への `push`** |
 | 発火しない例 | `develop` への push、任意ブランチへの push、`main` / `release` / `doc-site` などへの PR |
-| 重いジョブのスキップ | 同一 head SHA に成功済みの `CI` ワークフローがある、または docs のみの変更 |
-| docs のみ | `docs/**`・`site/content/**`・`*.md` 等のみ → GitHub 上は Test/Build スキップ。ローカル act は原則フル実行 |
+| 重いジョブのスキップ | 同一 head SHA に成功済みの `CI` ワークフローがある、または docs/site のみの変更（**PR と push の両方**） |
+| docs/site のみ | `docs/**`・`site/**`・`*.md`・docs 系 deploy ワークフロー等のみ → GitHub 上は Test/Build スキップ（`main` / `release` push も含む）。ローカル act は原則フル実行 |
 | ジョブ | `Gate` のあと **`Test & Build` 単一ジョブ**（`npm ci` 1回 → test → build）。site ワークスペースは入れない |
 | required check 名 | **`Test & Build`**（重い処理をスキップしてもジョブ自体は常に成功/失敗を報告） |
-| `main` push の理由 | Codecov default branch の coverage 更新（#121） |
+| `main` push の理由 | Codecov default branch の coverage 更新（#121）。コード push ごとにアプリ CI は **1回**。docs/site のみの push は重い処理をスキップ |
 | `release` push の理由 | release 由来タグ SHA に CI 履歴を付け、publish の Test スキップを効かせる |
+| 対象外 | GitHub **CodeQL** default setup（`dynamic/github-code-scanning/codeql`）は別ワークフローで、`main` push 時に併せて動くことがある |
 
 ## Docs CI（`.github/workflows/ci-docs.yml`）
 
 | 項目 | ルール |
 |------|--------|
 | トリガ | base が `doc-site` の `pull_request` |
-| ジョブ | **`Docs Build`**: スコープ付き `npm ci`（site + library/data）+ `npm run build:site` |
+| 重いジョブのスキップ | **コンテンツのみ**の変更 → サイトビルドをスキップ（チェック自体は成功扱い） |
+| コンテンツのみ | `docs/**`・`site/content/**`・`site/public/**`・`*.md`・`site/site.meta.yaml.example` など |
+| フル Docs Build | サイトの JS / 設定変更（例: `site/app/**`、`site/server/**`、`nuxt.config.ts`、`package.json`、i18n など） |
+| ジョブ | **`Docs Build`**: スキップしないときスコープ付き `npm ci`（site + library/data）+ `npm run build:site` |
 | 対象外 | アプリの `npm test`、アプリ単体の検証、およびアプリ CI の成否 — **`doc-site` へのマージ判定では無視** |
+| Deploy は続く | コンテンツのみでも `doc-site` へのマージ後は **Deploy Docs** が走り Pages を更新する |
 
 ### PR の向け先
 
@@ -126,8 +131,8 @@ release への push → CI（publish スキップ用の履歴）
 release 上のタグ → Release → Publish（Test 再利用 or 再検証、Build は常時）→ npm
 
 # ドキュメントサイト
-サイト変更 → doc-site へ PR
-          → Docs CI（"Docs Build"）
-          → doc-site へマージ → Deploy Docs → GitHub Pages（Actions）
+サイト JS/設定 → doc-site へ PR → Docs CI（"Docs Build"）
+コンテンツのみ → doc-site へ PR → Docs CI Gate がビルドをスキップ
+              → doc-site へマージ → Deploy Docs → GitHub Pages（Actions）
 ```
 

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -36,20 +36,25 @@ Do not open or update a PR while this gate is failing.
 |------|------|
 | Trigger | `pull_request` whose **base** is `develop` or `dev-*`; `push` to **`main`** or **`release`** |
 | Not triggered | Push to `develop` / arbitrary branches; PRs into `main` / `release` / `doc-site` / other bases |
-| Skip heavy jobs | Same head SHA already has a successful `CI` workflow run; or docs-only change set |
-| Docs-only | Changes limited to `docs/**`, `site/content/**`, `*.md` (and similar) → skip Test/Build on GitHub; local act still runs full jobs by default |
+| Skip heavy jobs | Same head SHA already has a successful `CI` workflow run; or docs/site-only change set (**PR and push**) |
+| Docs/site-only | Changes limited to `docs/**`, `site/**`, `*.md`, docs deploy workflows, and similar → skip Test/Build on GitHub (including `main` / `release` pushes). Local act still runs full jobs by default |
 | Jobs | `Gate` then a single **`Test & Build`** job (`npm ci` once → test → build). Site workspace is not installed |
 | Required check name | **`Test & Build`** (stable for branch protection; job always reports, even when heavy work is skipped) |
-| Why `main` push | Codecov default-branch coverage upload (#121) |
+| Why `main` push | Codecov default-branch coverage upload (#121) — **one** app CI run per code push; docs/site-only pushes skip heavy work |
 | Why `release` push | Tag SHAs created from `release` get CI history so publish can skip Test |
+| Not this workflow | GitHub **CodeQL** default setup is separate (`dynamic/github-code-scanning/codeql`) and may also run on `main` pushes |
 
 ## Docs CI (`.github/workflows/ci-docs.yml`)
 
 | Item | Rule |
 |------|------|
 | Trigger | `pull_request` whose **base** is `doc-site` |
-| Job | **`Docs Build`**: scoped `npm ci` (site + library/data) + `npm run build:site` |
+| Skip heavy jobs | **Content-only** change set → skip site build (check still reports success) |
+| Content-only | `docs/**`, `site/content/**`, `site/public/**`, `*.md`, `site/site.meta.yaml.example`, and similar |
+| Full Docs Build | Any change under site logic/config (e.g. `site/app/**`, `site/server/**`, `nuxt.config.ts`, `package.json`, i18n, workflows that affect the site build) |
+| Job | **`Docs Build`**: scoped `npm ci` (site + library/data) + `npm run build:site` when not skipped |
 | Out of scope | App `npm test`, app package-only verification, and app CI success/failure — **ignored** for merging into `doc-site` |
+| Deploy still runs | Content-only merges to `doc-site` still trigger **Deploy Docs** so Pages stays up to date |
 
 ### PR targets
 
@@ -126,8 +131,8 @@ release push → CI (history for publish skip)
 tag on release → Release → Publish (reuse CI Test or re-verify; always Build) → npm
 
 # Documentation site
-site change → open PR to doc-site
-           → Docs CI ("Docs Build")
-           → merge to doc-site → Deploy Docs → GitHub Pages (Actions)
+site logic/config → open PR to doc-site → Docs CI ("Docs Build")
+content-only     → open PR to doc-site → Docs CI Gate skips build
+                 → merge to doc-site → Deploy Docs → GitHub Pages (Actions)
 ```
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

main マージやドキュメント更新でアプリ CI が余分に回っていた問題を直します。

- **App CI (`ci.yml`)**: docs/site のみの判定を **push（`main` / `release`）でも適用**。以前は PR 時だけスキップされ、ドキュメント同期の main マージでも Test/Build が走っていた（例: #141）
- スキップ対象を `site/**` 全体と docs 系 workflow（`ci-docs.yml` / `deploy-docs.yml`）まで拡大
- **Docs CI (`ci-docs.yml`)**: コンテンツのみ（`docs/**`・`site/content/**`・`site/public/**`・`*.md` 等）は Docs Build をスキップ。`site/app` / Nuxt 設定など JS・ロジック変更時は従来どおりビルド
- Deploy Docs はコンテンツ更新でも継続（Pages 反映のため）
- コード変更の `main` push では Codecov 用にアプリ CI が **1 回**走る想定は維持。併走しうる **CodeQL** は GitHub default setup 側（本リポジトリの workflow 外）
- `docs/ci-cd.md` / `docs/ci-cd.ja.md` を追従

## Test plan

- [ ] docs/site のみの変更を `main` に push → CI Gate が `docs-only` で Test/Build をスキップ
- [ ] パッケージ変更の `main` push → 従来どおり Test/Build + Codecov（アプリ CI は 1 回）
- [ ] `doc-site` 向け PR で content のみ → Docs Build スキップ
- [ ] `doc-site` 向け PR で `site/app` 等を変更 → Docs Build 実行
- [ ] content のみを `doc-site` にマージ → Deploy Docs は依然として走る

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a075fb-72a6-7508-b201-cf355c254933?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a075fb-72a6-7508-b201-cf355c254933&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

